### PR TITLE
Fix AutoBase unwrap option handling

### DIFF
--- a/examples/autobee-simple.js
+++ b/examples/autobee-simple.js
@@ -6,7 +6,7 @@ module.exports = class SimpleAutobee {
     this.autobase.start({
       unwrap: true,
       apply: applyAutobeeBatch,
-      view: core => new Hyperbee(core.unwrap(), {
+      view: core => new Hyperbee(core, {
         ...opts,
         extension: false
       })

--- a/examples/autobee-with-resolution.js
+++ b/examples/autobee-with-resolution.js
@@ -17,7 +17,7 @@ module.exports = class Autobee {
       unwrap: true,
       apply: applyAutobeeBatch,
       view: core => {
-        return new Hyperbee(core.unwrap(), {
+        return new Hyperbee(core, {
           ...opts,
           extension: false
         })

--- a/index.js
+++ b/index.js
@@ -230,7 +230,8 @@ module.exports = class Autobase extends EventEmitter {
     const core = new LinearizedCore(this, {
       header: { protocol: OUTPUT_PROTOCOL },
       view,
-      apply
+      apply,
+      unwrap
     })
     const session = core.session({ unwrap })
     this._viewSessions.add(session)

--- a/index.js
+++ b/index.js
@@ -230,7 +230,7 @@ module.exports = class Autobase extends EventEmitter {
     const core = new LinearizedCore(this, {
       header: { protocol: OUTPUT_PROTOCOL },
       view,
-      apply,
+      apply
     })
     const session = core.session({ unwrap })
     this._viewSessions.add(session)
@@ -618,7 +618,7 @@ module.exports = class Autobase extends EventEmitter {
     }
   }
 
-  async _close () {    
+  async _close () {
     if (this.closed) return
     await this._opening
     for (const input of this.inputs) {

--- a/index.js
+++ b/index.js
@@ -231,9 +231,8 @@ module.exports = class Autobase extends EventEmitter {
       header: { protocol: OUTPUT_PROTOCOL },
       view,
       apply,
-      unwrap
     })
-    const session = core.session()
+    const session = core.session({ unwrap })
     this._viewSessions.add(session)
     this.view = view ? view(session) : session
   }

--- a/lib/linearize.js
+++ b/lib/linearize.js
@@ -396,6 +396,7 @@ class LinearizedCore {
     this.status = opts.status || { appended: 0, truncated: 0 }
     this.length = opts.length || 0
 
+    this._unwrap = opts.unwrap
     this._writable = opts.writable !== false
     this._applying = null
     this._viewSession = null
@@ -418,7 +419,7 @@ class LinearizedCore {
       this._applying = node
 
       if (!this.view) {
-        const session = this.session({ pin: true })
+        const session = this.session({ pin: true, unwrap: this._unwrap })
         this._viewSession = session
         this.view = this.viewFunction ? this.viewFunction(session) : session
       }


### PR DESCRIPTION
If an AutoBase is created with the {unwrap: true} option then this needs to be passed to core.session() and not to LinearizedCore as it's not stored nor used there.