### PR TITLE
Fix truncation event

### DIFF
--- a/lib/linearize.js
+++ b/lib/linearize.js
@@ -337,13 +337,23 @@ class Update {
     const appended = length - Math.max(p1.length, p2.length)
     const truncated = oldLength - p1.length
 
-    return { pending, nodes, length, appended, truncated, p1, p2 }
+    return {
+      oldLength,
+      length,
+      truncated,
+      appended,
+      nodes,
+      pending,
+      p1,
+      p2
+    }
   }
 
   async _executeLocal () {
     const oldLength = this.localOutput.length
     const { pending, p2 } = await this._findLocalAncestors()
     return {
+      oldLength,
       length: p2.length,
       truncated: oldLength - p2.length,
       appended: 0,
@@ -488,6 +498,8 @@ class LinearizedCore {
     this.length = this.status.length
     this.nodes = this.status.nodes
 
+    const truncationLength = this.status.oldLength - this.status.truncated
+
     try {
       await this._applyPending(this.status.pending)
     } catch (err) {
@@ -503,7 +515,7 @@ class LinearizedCore {
 
     if (this._writable && localOutput) {
       if (this.status.truncated) {
-        await localOutput.truncate(localOutput.length - this.status.truncated)
+        await localOutput.truncate(truncationLength)
       }
       if (localOutput.length === 0 && this.nodes.length) {
         this.nodes[0].header = this.header
@@ -512,7 +524,7 @@ class LinearizedCore {
     }
 
     for (const session of this._sessions) {
-      if (this.status.truncated) session.emit('truncate', this.lastUpdate.length - this.status.truncated)
+      if (this.status.truncated) session.emit('truncate', truncationLength)
       if (this.status.appended) session.emit('append')
     }
   }

--- a/test/common/local-linearizing.js
+++ b/test/common/local-linearizing.js
@@ -54,7 +54,7 @@ test('local linearizing - three independent forks', async t => {
   t.end()
 })
 
-test.only('local linearizing - three independent forks, two truncations', async t => {
+test('local linearizing - three independent forks, two truncations', async t => {
   t.plan(14)
 
   const output = new Hypercore(ram)


### PR DESCRIPTION
The `truncation` event has been emitting `NaN` forever because `Update.length` is not a valid property. This PR fixes that by returning `oldLength` from the `execute()` method, and then computing the truncation length from that.

Also adds a test that verifies the event is emitting the correct lengths during local linearization.