### PR TITLE
Fix potential simultaneous `apply()` calls from `.get()` call(s)

### DIFF
--- a/lib/linearize.js
+++ b/lib/linearize.js
@@ -2,6 +2,7 @@ const { EventEmitter } = require('events')
 const safetyCatch = require('safety-catch')
 const debounceify = require('debounceify')
 const b = require('b4a')
+const mutexify = require('mutexify/promise')
 
 const { OutputNode } = require('./nodes')
 const { eq } = require('./clock')
@@ -411,6 +412,7 @@ class LinearizedCore {
     this._viewSession = null
     this._sessions = []
     this._closed = false
+    this._rebuildLock = mutexify()
 
     this.update = debounceify(this._update.bind(this))
   }
@@ -469,6 +471,8 @@ class LinearizedCore {
     if (!this.autobase.opened) await this.autobase.ready()
     if (this._closed) return false
 
+    const release = await this._rebuildLock()
+
     const lastOutputs = this.lastUpdate ? this.lastUpdate.latestOutputs : null
     const localOutput = this.autobase.localOutput
 
@@ -487,9 +491,11 @@ class LinearizedCore {
     try {
       this.status = await this.lastUpdate.execute()
       await this._commitUpdate(localOutput)
+      release()
       return this.appended > 0
     } catch (err) {
       safetyCatch(err)
+      release()
       return false
     }
   }


### PR DESCRIPTION
`LinearizedCore._rebuild` can be called from two locations (`LinearizedCore._update` & `LinearizedCore.get` upon a retry failing) causing the `applyFunction` multiple times simultaneously. This will throw the 'Can only append to a LinearizedCore inside of an apply function' in `LinearizedCore.append` and the LinearizedCore's properties, such as `this.status`, to potentially be partially updated.

The fix was to add a mutexify lock for `LinearizedCore._rebuild` to block it from being run simultaneously. A test with an apply function with a delay added to ensure testing applys running at the same time.