### PR TITLE
Copy options when getting a session on a snapshotted LinearizedCoreSession

### DIFF
--- a/lib/linearize.js
+++ b/lib/linearize.js
@@ -755,14 +755,16 @@ class LinearizedCoreSession extends EventEmitter {
   }
 
   session (opts) {
+    const sessionOpts = { ...this.opts, ...opts }
+
     if (this._snapshotted) {
       // If a session is made on a snapshot, it's always bound to that snapshot
-      const session = new LinearizedCoreSession(this._core, opts)
+      const session = new LinearizedCoreSession(this._core, sessionOpts)
       session._snapshotIdx = this._snapshotSessions.push(session) - 1
       session._snapshot = this
       return session
     }
-    return this._core.session({ ...this.opts, ...opts })
+    return this._core.session(sessionOpts)
   }
 
   update () {

--- a/test/common/snapshotting.js
+++ b/test/common/snapshotting.js
@@ -195,6 +195,29 @@ test('snapshotting - concurrent snapshot updates will only migrate once', async 
   t.end()
 })
 
+test('snapshotting - creating session on snapshot copies options w/ overrides', async t => {
+  const output = new Hypercore(ram)
+  const writerA = new Hypercore(ram)
+
+  const base = new Autobase({
+    inputs: [writerA],
+    localOutput: output,
+    autostart: true
+  })
+
+  const s1 = base.view.snapshot({ unwrap: true })
+  const session1 = s1.session()
+
+  t.deepEqual(session1.opts, s1.opts, 'options get copied')
+
+  const s2 = base.view.snapshot({ unwrap: true })
+  const session2 = s2.session({ pin: true })
+
+  t.deepEqual(session2.opts, { ...s2.opts, pin: true }, 'support overrides')
+
+  t.end()
+})
+
 test('snapshotting - snapshot session close', async t => {
   // TODO: implement
   t.end()


### PR DESCRIPTION
Prior to this, options such as `unwrap` are lost when creating a session on a snapshotted LinearizedCoreSession.

An example of how this could cause problems is using autobase to create an Hyperbee index and then checking out the db, using snapshots for a diff stream etc.