### PR TITLE
Use exponential instead of linear search for `_findIntersection()`

### DIFF
--- a/lib/linearize.js
+++ b/lib/linearize.js
@@ -124,16 +124,52 @@ class OutputsBranch {
     // TODO: A galloping search would be optimal here, but this is good enough for the common cases.
     const cmp = operations - node.operations
     if (cmp > 0) {
-      while (seq < snapshot.length && operations > node.operations) {
-        seq += node.batch[1] + 1
-        if (seq >= snapshot.length) break
-        node = await snapshot.get(seq)
+      // Exponential Search : Finding lower bound
+      let bound = 1
+      while (bound < snapshot.length && operations > node.operations) {
+        bound *= 2
+        if (bound >= snapshot.length) break
+        node = await snapshot.get(bound)
+      }
+
+      // Binary Search
+      seq = bound / 2
+      let r = Math.min(bound + 1, snapshot.length)
+      while (seq <= r) {
+        const m = Math.floor((seq + r) / 2)
+        node = await snapshot.get(m)
+        if (operations > node.operations) {
+          seq = m + 1
+        } else if (operations < node.operations) {
+          r = m - 1
+        } else {
+          seq = m
+          break
+        }
       }
     } else if (cmp < 0) {
-      while (seq >= 0 && operations < node.operations) {
-        seq -= node.batch[0] + 1
-        if (seq < 0) break
-        node = await snapshot.get(seq)
+      // Exponential Search : Finding upper bound
+      let bound = 1
+      while (bound >= 0 && operations < node.operations) {
+        bound *= 2
+        if (snapshot.length - bound < 0) break
+        node = await snapshot.get(snapshot.length - bound)
+      }
+
+      // Binary Search : Starting at lower bound
+      seq = Math.max(snapshot.length - bound, 0)
+      let r = snapshot.length - (bound / 2) + 1
+      while (seq <= r) {
+        const m = Math.floor((seq + r) / 2)
+        node = await snapshot.get(m)
+        if (operations > node.operations) {
+          seq = m + 1
+        } else if (operations < node.operations) {
+          r = m - 1
+        } else {
+          seq = m
+          break
+        }
       }
     }
     if (!node || node.operations !== operations || !eq(node.clock, clock)) return null


### PR DESCRIPTION
Completing TODO comment (on [line #124](https://github.com/holepunchto/autobase/blob/master/lib/linearize.js#L124)) from @andrewosh add in 601c8fc.

I implemented the exponential search for both when finding an intersecting node above the first node and below. I did not see the below case fired in testing and so am not sure whether the exponential search was necessary in that case.

I implemented this because I encountered a scenario where the linear search was incredibly slow (taking minutes of time) even though the intersection being found was one / a few blocks back from the snapshot head. It also caused a read-only peer to download a large chunk of the remote outputs. With this fix, its fast and downloads only a few additional chunks to find the intersection.