### PR TITLE
Fix `append` not firing on sessions if view is fast-forwarded

### DIFF
--- a/lib/linearize.js
+++ b/lib/linearize.js
@@ -525,7 +525,7 @@ class LinearizedCore {
 
     for (const session of this._sessions) {
       if (this.status.truncated) session.emit('truncate', truncationLength)
-      if (this.status.appended) session.emit('append')
+      if (this.status.appended || this.length > truncationLength) session.emit('append')
     }
   }
 

--- a/test/common/remote-linearizing.js
+++ b/test/common/remote-linearizing.js
@@ -132,6 +132,11 @@ test('remote linearizing - can locally extend an out-of-date remote output', asy
     eagerUpdate: false
   })
 
+  let readerBaseAppends = 0
+  let readerBaseTruncates = 0
+  readerBase.view.on('append', () => readerBaseAppends++)
+  readerBase.view.on('truncate', () => readerBaseTruncates++)
+
   for (let i = 0; i < 3; i++) {
     await writerBase.append(`a${i}`, [], writerA)
   }
@@ -144,6 +149,8 @@ test('remote linearizing - can locally extend an out-of-date remote output', asy
   t.same(readerBase.view.status.appended, 0)
   t.same(readerBase.view.status.truncated, 0)
   t.same(readerBase.view.length, 3)
+  t.same(readerBaseAppends, 1)
+  t.same(readerBaseTruncates, 0)
 
   for (let i = 0; i < 2; i++) {
     await writerBase.append(`b${i}`, [], writerB)
@@ -153,6 +160,8 @@ test('remote linearizing - can locally extend an out-of-date remote output', asy
   t.same(readerBase.view.status.appended, 2)
   t.same(readerBase.view.status.truncated, 0)
   t.same(readerBase.view.length, 5)
+  t.same(readerBaseAppends, 2)
+  t.same(readerBaseTruncates, 0)
 
   for (let i = 0; i < 1; i++) {
     await writerBase.append(`c${i}`, [], writerC)
@@ -162,6 +171,8 @@ test('remote linearizing - can locally extend an out-of-date remote output', asy
   t.same(readerBase.view.status.appended, 1)
   t.same(readerBase.view.status.truncated, 0)
   t.same(readerBase.view.length, 6)
+  t.same(readerBaseAppends, 3)
+  t.same(readerBaseTruncates, 0)
 
   // Extend C and lock the previous forks (will not reorg)
   for (let i = 1; i < 4; i++) {
@@ -172,6 +183,8 @@ test('remote linearizing - can locally extend an out-of-date remote output', asy
   t.same(readerBase.view.status.appended, 3)
   t.same(readerBase.view.status.truncated, 0)
   t.same(readerBase.view.length, 9)
+  t.same(readerBaseAppends, 4)
+  t.same(readerBaseTruncates, 0)
 
   // Create a new B fork at the back (full reorg)
   for (let i = 1; i < 11; i++) {
@@ -182,6 +195,8 @@ test('remote linearizing - can locally extend an out-of-date remote output', asy
   t.same(readerBase.view.status.appended, 19)
   t.same(readerBase.view.status.truncated, 9)
   t.same(readerBase.view.length, 19)
+  t.same(readerBaseAppends, 5)
+  t.same(readerBaseTruncates, 1)
 
   t.end()
 })


### PR DESCRIPTION
When no localOutput is used, the status object usually has `appended` set to `0` because no blocks were added via `apply()`. Because the `append` event was emitted only when a status had a positive `appended` value, the `append` event would not fire on the view. This however doesn't reflect the "just a Hypercore" philosophy.

To preserve the status having `appended` `0` when fast-forwarding, a check was added to see if the length has increase compared to the old length or the new truncated length.

I initially wrote a separate test for the `append` and `truncate` events triggering on the view, but it was virtual identical to the `remote linearizing - can locally extend an out-of-date remote output` test. Since that is the only situation where this is even an issue, I added the event part of the test to the existing test case. I'm amenable to separating it out again if others think this should be its own test.