### PR TITLE
Fix hyperbee dependency version to support `db.getBySeq()`

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "b4a": "^1.6.1",
     "debounceify": "^1.0.0",
-    "hyperbee": "^2.4.2",
+    "hyperbee": "^2.15.0",
     "hypercore": "^10.33.0",
     "hypercore-crypto": "^3.4.0",
     "hypercore-id-encoding": "^1.2.0",


### PR DESCRIPTION
Hyperbee `2.15.0` is when `db.getBySeq()` was added. `autobase`'s `.system` db uses this so hyperbee versions prior to `2.15.0` don't work.