### PR TITLE
Revert hashing prologue into namespace

### DIFF
--- a/index.js
+++ b/index.js
@@ -560,8 +560,7 @@ module.exports = class Autobase extends ReadyResource {
     const w = this.activeWriters.get(key)
     if (!w) return null
 
-    const { prologue } = core.core.manifest
-    const namespace = w.deriveNamespace(core.name, prologue)
+    const namespace = w.deriveNamespace(core.name)
     const publicKey = w.core.manifest.signers[0].publicKey
 
     return {
@@ -1624,20 +1623,13 @@ module.exports = class Autobase extends ReadyResource {
   async _generateCheckpoint (cores) {
     if (!this._addCheckpoints) return null
 
-    // indexer set to sign for
-    const length = this.system.core._source.pendingIndexedLength
-    const checkout = await this.system.checkout(length)
-
-    const migrated = checkout.sameIndexers(this.linearizer.indexers)
-    await checkout.close()
-
     if (this._firstCheckpoint) {
       this._firstCheckpoint = false
       // TODO: unsafe, use an array instead for views as the order is important
-      return generateCheckpoint(this._viewStore.opened.values(), migrated)
+      return generateCheckpoint(this._viewStore.opened.values())
     }
 
-    return generateCheckpoint(cores, migrated)
+    return generateCheckpoint(cores)
   }
 
   async _flushLocal (localNodes) {
@@ -1646,24 +1638,13 @@ module.exports = class Autobase extends ReadyResource {
     const cores = this._addCheckpoints ? this._viewStore.getIndexedCores() : []
     const blocks = new Array(localNodes.length)
 
-    let migrated = false
-    let closing = null
-
-    if (this._addCheckpoints) {
-      const length = this.system.core._source.pendingIndexedLength
-      const checkout = await this.system.checkout(length)
-
-      migrated = checkout.sameIndexers(this.linearizer.indexers)
-      closing = checkout.close()
-    }
-
     for (let i = 0; i < blocks.length; i++) {
       const { value, heads, batch } = localNodes[i]
 
       blocks[i] = {
         version: 0,
         digest: this._addCheckpoints ? this._generateDigest() : null,
-        checkpoint: this._addCheckpoints ? await generateCheckpoint(cores, migrated) : null,
+        checkpoint: this._addCheckpoints ? await generateCheckpoint(cores) : null,
         node: {
           heads,
           batch,
@@ -1680,7 +1661,6 @@ module.exports = class Autobase extends ReadyResource {
     }
 
     await this.local.append(blocks)
-    await closing
 
     if (this._addCheckpoints) {
       const { checkpoint } = blocks[blocks.length - 1]
@@ -1691,11 +1671,11 @@ module.exports = class Autobase extends ReadyResource {
   }
 }
 
-function generateCheckpoint (cores, migrated) {
+function generateCheckpoint (cores) {
   const checkpoint = []
 
   for (const core of cores) {
-    checkpoint.push(core.checkpoint(migrated))
+    checkpoint.push(core.checkpoint())
     core.checkpointer++
   }
 

--- a/lib/core.js
+++ b/lib/core.js
@@ -573,31 +573,19 @@ module.exports = class Autocore extends ReadyResource {
     }
   }
 
-  async checkpoint (migrated) {
+  async checkpoint () {
     return {
       checkpointer: this.indexing === 0 ? this.checkpointer : 0,
-      checkpoint: (this.checkpointer && this.indexing === 0) ? null : await this._checkpoint(migrated)
+      checkpoint: (this.checkpointer && this.indexing === 0) ? null : await this._checkpoint()
     }
   }
 
-  async _checkpoint (migrated) {
+  async _checkpoint () {
     if (!this._lastCheckpoint || this._lastCheckpoint.length < this.pendingIndexedLength) {
-      await this._updateCheckpoint(migrated)
+      await this._updateCheckpoint()
     }
 
     return this._lastCheckpoint
-  }
-
-  _getPrologue (batch, migrated) {
-    // in case of migration we need to anticipate the next prologue
-    if (migrated) {
-      return {
-        hash: batch.hash(),
-        length: batch.length
-      }
-    }
-
-    return this.core.manifest.prologue
   }
 
   async _updateCheckpoint (migrated) {

--- a/lib/store.js
+++ b/lib/store.js
@@ -135,7 +135,7 @@ module.exports = class AutoStore {
     ac.systemIndex = -1
   }
 
-  deriveNamespace (name, entropy, prologue) {
+  deriveNamespace (name, entropy) {
     const encryptionId = crypto.hash(this.base.encryptionKey || EMPTY)
     const version = c.encode(c.uint, INDEX_VERSION)
     const bootstrap = this.base.bootstrap
@@ -145,7 +145,6 @@ module.exports = class AutoStore {
       version,
       bootstrap,
       encryptionId,
-      encodePrologue(prologue),
       entropy,
       b4a.from(name)
     ])
@@ -196,7 +195,7 @@ module.exports = class AutoStore {
     }
 
     const signers = indexers.map(idx => ({
-      namespace: this.deriveNamespace(name, idx.core.manifest.signers[0].namespace, prologue),
+      namespace: this.deriveNamespace(name, idx.core.manifest.signers[0].namespace),
       signature: 'ed25519',
       publicKey: idx.core.manifest.signers[0].publicKey
     }))
@@ -223,17 +222,6 @@ function staticManifest (hash) {
       length: 0
     }
   }
-}
-
-function encodePrologue (p) {
-  const state = { start: 0, end: 40, buffer: b4a.alloc(40) }
-
-  if (p) {
-    c.fixed32.encode(state, p.hash)
-    c.uint64.encode(state, p.length)
-  }
-
-  return state.buffer
 }
 
 function getBlockKey (bootstrap, encryptionKey, name) {

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -115,9 +115,9 @@ module.exports = class Writer extends ReadyResource {
     return true
   }
 
-  deriveNamespace (name, prologue) {
+  deriveNamespace (name) {
     const { namespace } = this.core.manifest.signers[0]
-    return this.base._viewStore.deriveNamespace(name, namespace, prologue)
+    return this.base._viewStore.deriveNamespace(name, namespace)
   }
 
   get (seq) {


### PR DESCRIPTION
Redundant now that Hypercore hashes manifest into signable 