### PR TITLE
Refactor test helpers

### DIFF
--- a/test/basic.js
+++ b/test/basic.js
@@ -9,7 +9,6 @@ const Autobase = require('..')
 const {
   create,
   replicateAndSync,
-  apply,
   addWriter,
   addWriterAndSync,
   confirm,
@@ -19,7 +18,8 @@ const {
 } = require('./helpers')
 
 test('basic - two writers', async t => {
-  const [base1, base2, base3] = await create(3, apply)
+  const { bases } = await create(3, t, { open: null })
+  const [base1, base2, base3] = bases
 
   await addWriter(base1, base2)
 
@@ -42,7 +42,8 @@ test('basic - two writers', async t => {
 
 test('basic - writable event fires', async t => {
   t.plan(1)
-  const [base1, base2] = await create(2, apply)
+  const { bases } = await create(2, t, { open: null })
+  const [base1, base2] = bases
 
   base2.on('writable', () => {
     t.ok(base2.writable, 'Writable event fired when autobase writable')
@@ -55,7 +56,8 @@ test('basic - writable event fires', async t => {
 
 test('basic - local key pair', async t => {
   const keyPair = crypto.keyPair()
-  const [base] = await create(1, apply, store => store.get('test', { valueEncoding: 'json' }), null, { keyPair })
+  const { bases } = await create(1, t, { keyPair })
+  const [base] = bases
 
   const block = { message: 'hello, world!' }
   await base.append(block)
@@ -66,7 +68,8 @@ test('basic - local key pair', async t => {
 })
 
 test('basic - view', async t => {
-  const [base] = await create(1, apply, store => store.get('test', { valueEncoding: 'json' }))
+  const { bases } = await create(1, t)
+  const [base] = bases
 
   const block = { message: 'hello, world!' }
   await base.append(block)
@@ -77,7 +80,8 @@ test('basic - view', async t => {
 })
 
 test('basic - view with close', async t => {
-  const [base] = await create(1, apply, open, close)
+  const { bases } = await create(1, t, { open, close })
+  const [base] = bases
 
   const block = { message: 'hello, world!' }
   await base.append(block)
@@ -106,7 +110,7 @@ test('basic - view with close', async t => {
 })
 
 test('basic - view/writer userdata is set', async t => {
-  const bases = await create(2, apply, store => store.get('test', { valueEncoding: 'json' }))
+  const { bases } = await create(2, t)
   const [base1, base2] = bases
 
   await addWriter(base1, base2)
@@ -130,7 +134,7 @@ test('basic - view/writer userdata is set', async t => {
 })
 
 test('basic - compare views', async t => {
-  const bases = await create(2, apply, store => store.get('test', { valueEncoding: 'json' }))
+  const { bases } = await create(2, t)
 
   const [a, b] = bases
   await addWriter(a, b)
@@ -148,7 +152,7 @@ test('basic - compare views', async t => {
 })
 
 test('basic - online majority', async t => {
-  const bases = await create(3, apply, store => store.get('test', { valueEncoding: 'json' }))
+  const { bases } = await create(3, t)
 
   const [a, b, c] = bases
 
@@ -188,7 +192,7 @@ test('basic - online majority', async t => {
 })
 
 test('basic - rotating majority', async t => {
-  const bases = await create(3, apply, store => store.get('test', { valueEncoding: 'json' }))
+  const { bases } = await create(3, t)
 
   const [a, b, c] = bases
 
@@ -267,7 +271,7 @@ test('basic - rotating majority', async t => {
 })
 
 test('basic - throws', async t => {
-  const bases = await create(2, apply, store => store.get('test', { valueEncoding: 'json' }))
+  const { bases } = await create(2, t)
 
   const [a, b] = bases
 
@@ -283,7 +287,7 @@ test('basic - throws', async t => {
 })
 
 test('basic - add 5 writers', async t => {
-  const bases = await create(5, apply, store => store.get('test', { valueEncoding: 'json' }))
+  const { bases } = await create(5, t)
 
   const [a, b, c, d, e] = bases
 
@@ -316,7 +320,7 @@ test('basic - add 5 writers', async t => {
 })
 
 test('basic - online minorities', async t => {
-  const bases = await create(5, apply, store => store.get('test', { valueEncoding: 'json' }))
+  const { bases } = await create(5, t)
 
   const [a, b, c, d, e] = bases
 
@@ -411,7 +415,7 @@ test('basic - restarting sets bootstrap correctly', async t => {
 })
 
 test('batch append', async t => {
-  const bases = await create(2, apply, store => store.get('test', { valueEncoding: 'json' }))
+  const { bases } = await create(2, t)
 
   const [a, b] = bases
   a.on('error', (e) => console.error(e))
@@ -426,7 +430,7 @@ test('batch append', async t => {
 })
 
 test('undoing a batch', async t => {
-  const bases = await create(2, apply, store => store.get('test', { valueEncoding: 'json' }))
+  const { bases } = await create(2, t)
 
   const [a, b] = bases
   a.on('error', (e) => console.error(e))
@@ -448,7 +452,7 @@ test('undoing a batch', async t => {
 })
 
 test('append during reindex', async t => {
-  const bases = await create(4, apply, store => store.get('test', { valueEncoding: 'json' }))
+  const { bases } = await create(4, t)
 
   const [a, b, c, d] = bases
 
@@ -483,7 +487,8 @@ test('append during reindex', async t => {
 })
 
 test('closing an autobase', async t => {
-  const [base] = await create(1, apply, store => store.get('test'))
+  const { bases } = await create(1, t)
+  const [base] = bases
 
   // Sanity check
   t.is(base.local.closed, false)
@@ -493,7 +498,7 @@ test('closing an autobase', async t => {
 })
 
 test('flush after reindex', async t => {
-  const bases = await create(9, apply, store => store.get('test', { valueEncoding: 'json' }))
+  const { bases } = await create(9, t)
 
   const root = bases[0]
   const adds = []
@@ -523,7 +528,7 @@ test('flush after reindex', async t => {
 })
 
 test('reindex', async t => {
-  const bases = await create(5, apply, store => store.get('test', { valueEncoding: 'json' }))
+  const { bases } = await create(5, t)
 
   const [a, b, c, d, e] = bases
 
@@ -583,7 +588,7 @@ test('reindex', async t => {
 })
 
 test('sequential restarts', async t => {
-  const bases = await create(9, apply, store => store.get('test', { valueEncoding: 'json' }))
+  const { bases } = await create(9, t)
 
   const root = bases[0]
   const adds = []
@@ -648,7 +653,8 @@ test('sequential restarts', async t => {
 })
 
 test('two writers write many messages, third writer joins', async t => {
-  const [base1, base2, base3] = await create(3, apply, store => store.get('test', { valueEncoding: 'json' }))
+  const { bases } = await create(3, t)
+  const [base1, base2, base3] = bases
 
   await addWriter(base1, base2)
 
@@ -667,7 +673,8 @@ test('two writers write many messages, third writer joins', async t => {
 })
 
 test('basic - gc indexed nodes', async t => {
-  const [base] = await create(1, apply, store => store.get('test', { valueEncoding: 'json' }))
+  const { bases } = await create(1, t)
+  const [base] = bases
 
   await base.append({ message: '0' })
   await base.append({ message: '1' })
@@ -687,7 +694,8 @@ test('basic - gc indexed nodes', async t => {
 })
 
 test('basic - isAutobase', async t => {
-  const [base1, base2, base3] = await create(3, apply)
+  const { bases } = await create(3, t, { open: null })
+  const [base1, base2, base3] = bases
 
   await addWriter(base1, base2)
 
@@ -710,7 +718,9 @@ test('basic - isAutobase', async t => {
 test('basic - catch apply throws', async t => {
   t.plan(1)
 
-  const [a] = await create(1, apply, store => store.get('test', { valueEncoding: 'json' }))
+  const { bases } = await create(1, t)
+  const [a] = bases
+
   const b = new Autobase(new Corestore(ram, { primaryKey: Buffer.alloc(32).fill(1) }), a.local.key, {
     apply: applyThrow,
     valueEncoding: 'json',
@@ -753,7 +763,8 @@ test('basic - catch apply throws', async t => {
 })
 
 test('basic - non-indexed writer', async t => {
-  const [a, b] = await create(2, applyWriter, store => store.get('test', { valueEncoding: 'json' }))
+  const { bases } = await create(2, t, { apply: applyWriter })
+  const [a, b] = bases
 
   await a.append({ add: b.local.key.toString('hex'), indexer: false })
 
@@ -824,7 +835,8 @@ test('basic - non-indexed writer', async t => {
 })
 
 test('basic - non-indexed writers 3-of-5', async t => {
-  const [a, b, c, d, e] = await create(5, applyWriter, store => store.get('test', { valueEncoding: 'json' }))
+  const { bases } = await create(5, t, { apply: applyWriter })
+  const [a, b, c, d, e] = bases
 
   await a.append({ add: b.local.key.toString('hex'), indexer: true })
   await a.append({ add: c.local.key.toString('hex'), indexer: true })
@@ -946,7 +958,8 @@ test('autobase should not detach the original store', async t => {
 })
 
 test('basic - oplog digest', async t => {
-  const [base1, base2] = await create(2, apply)
+  const { bases } = await create(2, t, { open: null })
+  const [base1, base2] = bases
 
   await base1.append({
     add: base2.local.key.toString('hex'),
@@ -966,10 +979,12 @@ test('basic - oplog digest', async t => {
   t.is(last.digest.indexers?.length, 2)
 })
 
-test('basic - close during apply', async t => {
-  const [a] = await create(
-    1,
-    async function apply (nodes, view, base) {
+// todo: this is broken if a store session is passed to the base
+test.skip('basic - close during apply', async t => {
+  t.plan(1)
+
+  const { bases } = await create(1, t, {
+    async apply (nodes, view, base) {
       for (const node of nodes) {
         if (node.value.add) {
           await base.addWriter(b4a.from(node.value.add, 'hex'))
@@ -979,9 +994,10 @@ test('basic - close during apply', async t => {
         const core = view._source.core.session
         await core.get(core.length) // can never resolve
       }
-    },
-    store => store.get('test', { valueEncoding: 'json' })
-  )
+    }
+  })
+
+  const [a] = bases
 
   const promise = a.append('hello')
   setImmediate(() => a.close())
@@ -990,7 +1006,7 @@ test('basic - close during apply', async t => {
 })
 
 test('basic - constructor throws', async t => {
-  await t.exception(create(1, undefined, open), /Synthetic./)
+  await t.exception(create(1, t, { apply: undefined, open }), /Synthetic./)
 
   function open () {
     throw new Error('Synthetic.')
@@ -998,7 +1014,7 @@ test('basic - constructor throws', async t => {
 })
 
 test('basic - never sign past pending migration', async t => {
-  const bases = await create(5, apply, store => store.get('test', { valueEncoding: 'json' }))
+  const { bases } = await create(5, t)
 
   const [a, b, c, d, e] = bases
 
@@ -1025,7 +1041,8 @@ test('basic - never sign past pending migration', async t => {
 })
 
 test('basic - remove writer', async t => {
-  const [a, b, c] = await create(3, applyWithRemove)
+  const { bases } = await create(3, t, { apply: applyWithRemove, open: null })
+  const [a, b, c] = bases
 
   await addWriter(a, b, false)
 
@@ -1047,7 +1064,8 @@ test('basic - remove writer', async t => {
 })
 
 test('basic - remove indexer', async t => {
-  const [a, b, c] = await create(3, applyWithRemove)
+  const { bases } = await create(3, t, { apply: applyWithRemove, open: null })
+  const [a, b, c] = bases
 
   await addWriterAndSync(a, b)
   await b.append(null)
@@ -1077,7 +1095,8 @@ test('basic - remove indexer', async t => {
 })
 
 test('basic - remove indexer and continue indexing', async t => {
-  const [a, b, c] = await create(3, applyWithRemove, store => store.get('test'))
+  const { bases } = await create(3, t, { apply: applyWithRemove })
+  const [a, b, c] = bases
 
   await addWriterAndSync(a, b)
   await addWriterAndSync(b, c)
@@ -1106,7 +1125,8 @@ test('basic - remove indexer and continue indexing', async t => {
 })
 
 test('basic - remove indexer back to previously used indexer set', async t => {
-  const [a, b, c] = await create(3, applyWithRemove, store => store.get('test'))
+  const { bases } = await create(3, t, { apply: applyWithRemove })
+  const [a, b, c] = bases
 
   await addWriterAndSync(a, b)
 
@@ -1150,7 +1170,8 @@ test('basic - remove indexer back to previously used indexer set', async t => {
 })
 
 test('basic - remove an indexer when 2-of-2', async t => {
-  const [a, b] = await create(2, applyWithRemove, store => store.get('test'))
+  const { bases } = await create(2, t, { apply: applyWithRemove })
+  const [a, b] = bases
 
   await addWriterAndSync(a, b)
 
@@ -1189,7 +1210,8 @@ test('basic - remove an indexer when 2-of-2', async t => {
 })
 
 test('basic - remove multiple indexers concurrently', async t => {
-  const [a, b, c] = await create(3, apply, store => store.get('test'))
+  const { bases } = await create(3, t, { apply })
+  const [a, b, c] = bases
 
   await addWriterAndSync(a, b)
   await addWriterAndSync(b, c)

--- a/test/basic.js
+++ b/test/basic.js
@@ -980,7 +980,7 @@ test('basic - oplog digest', async t => {
   t.is(last.digest.indexers?.length, 2)
 })
 
-// todo: this is broken if a store session is passed to the base
+// todo: use normal helper once we have hypercore session manager
 test('basic - close during apply', async t => {
   t.plan(1)
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -980,7 +980,7 @@ test('basic - oplog digest', async t => {
 })
 
 // todo: this is broken if a store session is passed to the base
-test.skip('basic - close during apply', async t => {
+test.solo('basic - close during apply', async t => {
   t.plan(1)
 
   const { bases } = await create(1, t, {

--- a/test/basic.js
+++ b/test/basic.js
@@ -8,6 +8,7 @@ const Autobase = require('..')
 
 const {
   create,
+  createStores,
   replicateAndSync,
   addWriter,
   addWriterAndSync,
@@ -980,10 +981,11 @@ test('basic - oplog digest', async t => {
 })
 
 // todo: this is broken if a store session is passed to the base
-test.solo('basic - close during apply', async t => {
+test('basic - close during apply', async t => {
   t.plan(1)
 
-  const { bases } = await create(1, t, {
+  const [store] = await createStores(1, t)
+  const a = new Autobase(store, null, {
     async apply (nodes, view, base) {
       for (const node of nodes) {
         if (node.value.add) {
@@ -994,10 +996,9 @@ test.solo('basic - close during apply', async t => {
         const core = view._source.core.session
         await core.get(core.length) // can never resolve
       }
-    }
+    },
+    valueEncoding: 'json'
   })
-
-  const [a] = bases
 
   const promise = a.append('hello')
   setImmediate(() => a.close())

--- a/test/core.js
+++ b/test/core.js
@@ -4,7 +4,6 @@ const Hypercore = require('hypercore')
 
 const {
   create,
-  apply,
   addWriter,
   addWriterAndSync,
   confirm,
@@ -12,7 +11,9 @@ const {
 } = require('./helpers')
 
 test('core -  no new session if closed (hypercore compat)', async t => {
-  const [base] = await create(1, apply, store => store.get('test'))
+  const { bases } = await create(1, t)
+  const [base] = bases
+
   const normalCore = new Hypercore(ram)
   const linearizedSessionCore = base.view
   const snapshotSession = linearizedSessionCore.snapshot()
@@ -37,7 +38,8 @@ test('core -  no new session if closed (hypercore compat)', async t => {
 })
 
 test('core - seek', async t => {
-  const [base] = await create(1, apply, store => store.get('test'))
+  const { bases } = await create(1, t)
+  const [base] = bases
 
   const b1 = base.view.byteLength
   await base.append('hello')
@@ -63,7 +65,12 @@ test('core - seek', async t => {
 })
 
 test('core - seek multi writer', async t => {
-  const [a, b] = await create(2, scopedApply, store => store.get('test'))
+  const { bases } = await create(2, t, {
+    apply: scopedApply,
+    open: store => store.get('test')
+  })
+
+  const [a, b] = bases
 
   await addWriter(a, b)
   await confirm([a, b])
@@ -112,7 +119,8 @@ test('core - seek multi writer', async t => {
 })
 
 test('core - userData', async t => {
-  const [base] = await create(1, apply, store => store.get('test'))
+  const { bases } = await create(1, t)
+  const [base] = bases
 
   await base.view.setUserData('first', Buffer.from('hello'))
   await base.view.setUserData('second', Buffer.from('goodbye'))
@@ -131,7 +139,8 @@ test('core - userData', async t => {
 })
 
 test('core - properties', async t => {
-  const [base] = await create(1, apply, store => store.get('test'))
+  const { bases } = await create(1, t)
+  const [base] = bases
 
   await base.append('hello, world!')
 
@@ -142,7 +151,8 @@ test('core - properties', async t => {
 })
 
 test('core - indexed view', async t => {
-  const [a, b] = await create(2, apply, store => store.get('test'))
+  const { bases } = await create(2, t)
+  const [a, b] = bases
 
   const normal = a.view.session({ snapshot: false })
   const indexed = a.view.session({ snapshot: false, indexed: true })

--- a/test/dags.js
+++ b/test/dags.js
@@ -4,7 +4,6 @@ const {
   create,
   replicateAndSync,
   addWriterAndSync,
-  apply,
   confirm,
   compareViews
 } = require('./helpers')
@@ -12,7 +11,7 @@ const {
 // a - b - a
 
 test('simple 2', async t => {
-  const bases = await create(2, apply, store => store.get('test', { valueEncoding: 'json' }))
+  const { bases } = await create(2, t)
 
   const [a, b] = bases
 
@@ -49,7 +48,7 @@ c - b - a - c - b - a
 */
 
 test('simple 3', async t => {
-  const bases = await create(3, apply, store => store.get('test', { valueEncoding: 'json' }))
+  const { bases } = await create(3, t)
 
   const [a, b, c] = bases
 
@@ -109,7 +108,7 @@ c   a
 
 // known: test fails for current linearizer
 test.skip('convergence', async t => {
-  const bases = await create(3, apply, store => store.get('test', { valueEncoding: 'json' }))
+  const { bases } = await create(3, t)
 
   const [a, b, c] = bases
 
@@ -189,7 +188,7 @@ test.skip('convergence', async t => {
 
 // known: test fails for current linearizer
 test.skip('inner majority', async t => {
-  const bases = await create(5, apply, store => store.get('test', { valueEncoding: 'json' }))
+  const { bases } = await create(5, t)
 
   const [a, b, c, d, e] = bases
 
@@ -251,7 +250,7 @@ test.skip('inner majority', async t => {
 */
 
 test('majority alone - convergence', async t => {
-  const bases = await create(5, apply, store => store.get('test', { valueEncoding: 'json' }))
+  const { bases } = await create(5, t)
 
   const [a, b, c, d, e] = bases
 
@@ -302,7 +301,8 @@ test('majority alone - convergence', async t => {
 })
 
 test('add writer', async t => {
-  const [a, b, c] = await create(3, apply, store => store.get('test', { valueEncoding: 'json' }))
+  const { bases } = await create(3, t)
+  const [a, b, c] = bases
 
   let ai = 0
   let bi = 0
@@ -370,7 +370,7 @@ test('add writer', async t => {
 */
 
 test('majority alone - non-convergence', async t => {
-  const bases = await create(5, apply, store => store.get('test', { valueEncoding: 'json' }))
+  const { bases } = await create(5, t)
 
   const [a, b, c, d, e] = bases
 
@@ -450,7 +450,7 @@ test('majority alone - non-convergence', async t => {
 */
 
 test('double fork', async t => {
-  const bases = await create(5, apply, store => store.get('test', { valueEncoding: 'json' }))
+  const { bases } = await create(5, t)
 
   const [a, b, c, d, e] = bases
 

--- a/test/linearizer.js
+++ b/test/linearizer.js
@@ -5,8 +5,7 @@ const {
   create,
   confirm,
   replicateAndSync,
-  addWriterAndSync,
-  apply
+  addWriterAndSync
 } = require('./helpers')
 
 /*
@@ -16,7 +15,7 @@ c - b - a - c - b - a
 */
 
 test('linearizer - simple', async t => {
-  const bases = await create(3, apply, store => store.get('test', { valueEncoding: 'json' }))
+  const { bases } = await create(3, t)
 
   const [a, b, c] = bases
 
@@ -113,7 +112,7 @@ test('linearizer - simple', async t => {
 })
 
 test('linearizer - compete', async t => {
-  const bases = await create(3, apply, store => store.get('test', { valueEncoding: 'json' }))
+  const { bases } = await create(3, t)
 
   const [a, b, c] = bases
 
@@ -208,7 +207,7 @@ test('linearizer - compete', async t => {
 })
 
 test('linearizer - count ordering', async t => {
-  const bases = await create(3, apply, store => store.get('test', { valueEncoding: 'json' }))
+  const { bases } = await create(3, t)
 
   const [a, b, c] = bases
 
@@ -336,7 +335,7 @@ test('linearizer - count ordering', async t => {
 })
 
 test('linearizer - reordering', async t => {
-  const bases = await create(3, apply, store => store.get('test', { valueEncoding: 'json' }))
+  const { bases } = await create(3, t)
 
   const [a, b, c] = bases
 
@@ -382,7 +381,7 @@ test('linearizer - reordering', async t => {
 })
 
 test('linearizer - reordering after restart', async t => {
-  const bases = await create(3, apply, store => store.get('test', { valueEncoding: 'json' }))
+  const { bases } = await create(3, t)
 
   const [a, b, c] = bases
 
@@ -414,7 +413,7 @@ test('linearizer - reordering after restart', async t => {
 })
 
 test('linearizer - shouldAck', async t => {
-  const bases = await create(3, apply, store => store.get('test', { valueEncoding: 'json' }))
+  const { bases } = await create(3, t)
 
   const [a, b, c] = bases
 
@@ -447,7 +446,7 @@ test('linearizer - shouldAck', async t => {
 
 // review: test passes, but not sure what this test is for?
 test.skip('linearizer - no loop', async t => {
-  const bases = await create(4, apply, store => store.get('test', { valueEncoding: 'json' }))
+  const { bases } = await create(4, t)
 
   const [a, b, c, d] = bases
 

--- a/test/snapshots.js
+++ b/test/snapshots.js
@@ -4,7 +4,6 @@ const Hyperbee = require('hyperbee')
 const {
   create,
   confirm,
-  apply,
   addWriter,
   replicateAndSync
 } = require('./helpers')
@@ -12,7 +11,7 @@ const {
 const beeOpts = { extension: false, keyEncoding: 'binary', valueEncoding: 'binary' }
 
 test('check snapshot of snapshot after rebase', async t => {
-  const bases = await create(3, apply, store => store.get('test', { valueEncoding: 'json' }))
+  const { bases } = await create(3, t)
   const [base1, base2, base3] = bases
 
   await addWriter(base1, base2)
@@ -49,7 +48,7 @@ test('check snapshot of snapshot after rebase', async t => {
 })
 
 test('no inconsistent snapshot entries when truncated', async t => {
-  const bases = await create(3, apply, store => store.get('test', { valueEncoding: 'json' }))
+  const { bases } = await create(3, t)
   const [base1, base2, base3] = bases
 
   await base1.append({ add: base2.local.key.toString('hex') })
@@ -78,7 +77,7 @@ test('no inconsistent snapshot entries when truncated', async t => {
 })
 
 test('no inconsistent snapshot-of-snapshot entries when truncated', async t => {
-  const bases = await create(3, apply, store => store.get('test', { valueEncoding: 'json' }))
+  const { bases } = await create(3, t)
   const [base1, base2, base3] = bases
 
   await base1.append({ add: base2.local.key.toString('hex') })
@@ -113,7 +112,11 @@ test('no inconsistent snapshot-of-snapshot entries when truncated', async t => {
 
 test('no inconsistent entries when using snapshot core in bee (bee snapshot)', async t => {
   // Setup
-  const bases = await create(3, (...args) => applyForBee(t, ...args), openForBee)
+  const { bases } = await create(3, t, {
+    apply (...args) { return applyForBee(t, ...args) },
+    open: openForBee
+  })
+
   const [base1, base2, base3] = bases
 
   await base1.append({ add: base2.local.key.toString('hex') })
@@ -161,7 +164,7 @@ test('no inconsistent entries when using snapshot core in bee (bee snapshot)', a
 })
 
 test('check cloning detached snapshot', async t => {
-  const bases = await create(4, apply, store => store.get('test', { valueEncoding: 'json' }))
+  const { bases } = await create(4, t)
   const [base1, base2, base3, base4] = bases
 
   await addWriter(base1, base2)

--- a/test/suspend.js
+++ b/test/suspend.js
@@ -85,8 +85,7 @@ test('suspend - pass exisiting fs store', async t => {
 
   await base2.close()
 
-  const session3 = store.session()
-  const base3 = new Autobase(session3, base1.local.key, { apply, valueEncoding: 'json', ackInterval: 0, ackThreshold: 0, fastForward: false })
+  const base3 = await createBase(store, base1.local.key, t, { open: null })
   await base3.ready()
 
   t.is(base3.activeWriters.size, 2)

--- a/test/upgrade.js
+++ b/test/upgrade.js
@@ -13,7 +13,7 @@ const {
 } = require('./helpers')
 
 test('upgrade - do not proceed', async t => {
-  const [s1, s2] = await createStores(2)
+  const [s1, s2] = await createStores(2, t)
 
   const a0 = new Autobase(s1.session(), null, {
     apply: applyv0,
@@ -65,7 +65,7 @@ test('upgrade - do not proceed', async t => {
 })
 
 test('upgrade - proceed', async t => {
-  const [s1, s2] = await createStores(2)
+  const [s1, s2] = await createStores(2, t)
 
   const a0 = new Autobase(s1.session(), null, {
     apply: applyv0,
@@ -130,7 +130,7 @@ test('upgrade - proceed', async t => {
 })
 
 test('upgrade - consensus', async t => {
-  const [s1, s2] = await createStores(2)
+  const [s1, s2] = await createStores(2, t)
 
   const a0 = new Autobase(s1.session(), null, {
     apply: applyv0,
@@ -205,7 +205,7 @@ test('upgrade - consensus', async t => {
 })
 
 test('upgrade - consensus 3 writers', async t => {
-  const [s1, s2, s3] = await createStores(3)
+  const [s1, s2, s3] = await createStores(3, t)
 
   const a0 = new Autobase(s1.session(), null, {
     apply: applyv0,
@@ -318,7 +318,7 @@ test('upgrade - consensus 3 writers', async t => {
 })
 
 test('upgrade - writer cannot append while behind', async t => {
-  const [s1, s2, s3] = await createStores(3)
+  const [s1, s2, s3] = await createStores(3, t)
 
   const a0 = new Autobase(s1.session(), null, {
     apply: applyv0,
@@ -405,7 +405,7 @@ test('upgrade - writer cannot append while behind', async t => {
 })
 
 test('upgrade - onindex hook', async t => {
-  const [s1, s2] = await createStores(2)
+  const [s1, s2] = await createStores(2, t)
 
   let aversion = 0
   let bversion = 0
@@ -491,7 +491,7 @@ test('upgrade - onindex hook', async t => {
 })
 
 test('autobase upgrade - do not proceed', async t => {
-  const [s1, s2] = await createStores(2)
+  const [s1, s2] = await createStores(2, t)
 
   const a0 = new Autobase(s1.session(), null, {
     apply,
@@ -546,7 +546,7 @@ test('autobase upgrade - do not proceed', async t => {
 })
 
 test('autobase upgrade - proceed', async t => {
-  const [s1, s2] = await createStores(2)
+  const [s1, s2] = await createStores(2, t)
 
   const a0 = new Autobase(s1.session(), null, {
     apply,
@@ -617,7 +617,7 @@ test('autobase upgrade - proceed', async t => {
 })
 
 test('autobase upgrade - consensus', async t => {
-  const [s1, s2] = await createStores(2)
+  const [s1, s2] = await createStores(2, t)
 
   const a0 = new Autobase(s1.session(), null, {
     apply,
@@ -695,7 +695,7 @@ test('autobase upgrade - consensus', async t => {
 })
 
 test('autobase upgrade - consensus 3 writers', async t => {
-  const [s1, s2, s3] = await createStores(3)
+  const [s1, s2, s3] = await createStores(3, t)
 
   const a0 = new Autobase(s1.session(), null, {
     apply,


### PR DESCRIPTION
This PR makes the `create` test helper more ergonomic:

- helper handles teardown of all created instances
- specific options can be passed, otherwise defaults will be used.