### PR TITLE
Skip flaky test

### DIFF
--- a/test/fast-forward.js
+++ b/test/fast-forward.js
@@ -1,3 +1,4 @@
+const os = require('os')
 const test = require('brittle')
 const tmpDir = require('test-tmp')
 const cenc = require('compact-encoding')
@@ -13,6 +14,8 @@ const {
   create,
   createBase
 } = require('./helpers')
+
+const IS_MAC_OSX = os.platform === 'darwin'
 
 test('fast-forward - simple', async t => {
   t.plan(1)
@@ -245,77 +248,79 @@ test('fast-forward - multiple queues', async t => {
   }
 })
 
-test.skip('fast-forward - open with no remote io', async t => {
-  const { bases, stores } = await create(2, t, {
-    apply: applyOldState,
-    fastForward: true,
-    storage: () => tmpDir(t)
-  })
+if (!IS_MAC_OSX) {
+  test('fast-forward - open with no remote io', async t => {
+    const { bases, stores } = await create(2, t, {
+      apply: applyOldState,
+      fastForward: true,
+      storage: () => tmpDir(t)
+    })
 
-  const [a, b] = bases
+    const [a, b] = bases
 
-  await b.ready()
+    await b.ready()
 
-  for (let i = 0; i < 1000; i++) {
-    await a.append('a' + i)
-  }
-
-  await addWriterAndSync(a, b)
-  const unreplicate = replicate([a, b])
-
-  const core = b.view.getBackingCore()
-  const sparse = await isSparse(core)
-
-  t.ok(sparse > 0)
-  t.comment('sparse blocks: ' + sparse)
-
-  await b.append('b1')
-  await b.append('b2')
-  await b.append('b3')
-
-  await unreplicate()
-
-  await a.append('a1001')
-
-  await b.close()
-
-  const local = a.local
-  const remote = stores[1].get({ key: local.key })
-
-  const s1 = local.replicate(true)
-  const s2 = remote.replicate(false)
-
-  s1.pipe(s2).pipe(s1)
-
-  await remote.download({ end: local.length }).downloaded()
-
-  s1.destroy()
-  await new Promise(resolve => s2.on('close', resolve))
-
-  const b2 = await createBase(stores[1].session(), a.local.key, t, {
-    apply: applyOldState
-  })
-
-  await b2.ready()
-  await t.execution(b2.ready())
-
-  async function applyOldState (batch, view, base) {
-    for (const { value } of batch) {
-      if (value.add) {
-        const key = Buffer.from(value.add, 'hex')
-        await base.addWriter(key, { indexer: value.indexer })
-        continue
-      }
-
-      if (view) await view.append(value)
-      const core = view._source.core.session
-
-      // get well distributed unique index
-      const index = (view.length * 67 + view.length * 89) % core.length
-      if (core.length) await core.get(index)
+    for (let i = 0; i < 1000; i++) {
+      await a.append('a' + i)
     }
-  }
-})
+
+    await addWriterAndSync(a, b)
+    const unreplicate = replicate([a, b])
+
+    const core = b.view.getBackingCore()
+    const sparse = await isSparse(core)
+
+    t.ok(sparse > 0)
+    t.comment('sparse blocks: ' + sparse)
+
+    await b.append('b1')
+    await b.append('b2')
+    await b.append('b3')
+
+    await unreplicate()
+
+    await a.append('a1001')
+
+    await b.close()
+
+    const local = a.local
+    const remote = stores[1].get({ key: local.key })
+
+    const s1 = local.replicate(true)
+    const s2 = remote.replicate(false)
+
+    s1.pipe(s2).pipe(s1)
+
+    await remote.download({ end: local.length }).downloaded()
+
+    s1.destroy()
+    await new Promise(resolve => s2.on('close', resolve))
+
+    const b2 = await createBase(stores[1].session(), a.local.key, t, {
+      apply: applyOldState
+    })
+
+    await b2.ready()
+    await t.execution(b2.ready())
+
+    async function applyOldState (batch, view, base) {
+      for (const { value } of batch) {
+        if (value.add) {
+          const key = Buffer.from(value.add, 'hex')
+          await base.addWriter(key, { indexer: value.indexer })
+          continue
+        }
+
+        if (view) await view.append(value)
+        const core = view._source.core.session
+
+        // get well distributed unique index
+        const index = (view.length * 67 + view.length * 89) % core.length
+        if (core.length) await core.get(index)
+      }
+    }
+  })
+}
 
 test('fast-forward - force reset then ff', async t => {
   t.plan(9)

--- a/test/fast-forward.js
+++ b/test/fast-forward.js
@@ -245,7 +245,7 @@ test('fast-forward - multiple queues', async t => {
   }
 })
 
-test('fast-forward - open with no remote io', async t => {
+test.skip('fast-forward - open with no remote io', async t => {
   const { bases, stores } = await create(2, t, {
     apply: applyOldState,
     fastForward: true,


### PR DESCRIPTION
It's flaky on Mac. Good to skip it temporarily until we can fix it, so it doesn't break the CI