### PR TITLE
Document in test how snapshot indexedLength can increase

### DIFF
--- a/test/snapshots.js
+++ b/test/snapshots.js
@@ -110,7 +110,7 @@ test('no inconsistent snapshot-of-snapshot entries when truncated', async t => {
   t.alike(origValues2, newValues2)
 })
 
-test.solo('no inconsistent entries when using snapshot core in bee (bee snapshot)', async t => {
+test('no inconsistent entries when using snapshot core in bee (bee snapshot)', async t => {
   // Setup
   const { bases } = await create(3, t, {
     apply (...args) { return applyForBee(t, ...args) },
@@ -161,7 +161,7 @@ test.solo('no inconsistent entries when using snapshot core in bee (bee snapshot
   t.alike(keys2PreMerge, keys2PostMerge)
 
   t.is(hasTruncated, true) // Sanity check
-  t.is(bee1.core.indexedLength, 2, 'bee1 snapshot indexed length did not change')
+  t.is(bee1.core.indexedLength, 3, 'Snapshot indexedLength increased, because it is now confirmed')
   t.is(bee1.version, 3, 'bee1 snapshot version did not change')
 
   t.is(bee2.core.indexedLength, 2, 'bee2 snapshot indexed length did not change')

--- a/test/snapshots.js
+++ b/test/snapshots.js
@@ -110,7 +110,7 @@ test('no inconsistent snapshot-of-snapshot entries when truncated', async t => {
   t.alike(origValues2, newValues2)
 })
 
-test('no inconsistent entries when using snapshot core in bee (bee snapshot)', async t => {
+test.solo('no inconsistent entries when using snapshot core in bee (bee snapshot)', async t => {
   // Setup
   const { bases } = await create(3, t, {
     apply (...args) { return applyForBee(t, ...args) },
@@ -161,6 +161,11 @@ test('no inconsistent entries when using snapshot core in bee (bee snapshot)', a
   t.alike(keys2PreMerge, keys2PostMerge)
 
   t.is(hasTruncated, true) // Sanity check
+  t.is(bee1.core.indexedLength, 2, 'bee1 snapshot indexed length did not change')
+  t.is(bee1.version, 3, 'bee1 snapshot version did not change')
+
+  t.is(bee2.core.indexedLength, 2, 'bee2 snapshot indexed length did not change')
+  t.is(bee2.version, 4, 'bee2 snapshot version did not change')
 })
 
 test('check cloning detached snapshot', async t => {

--- a/test/snapshots.js
+++ b/test/snapshots.js
@@ -161,11 +161,11 @@ test('no inconsistent entries when using snapshot core in bee (bee snapshot)', a
   t.alike(keys2PreMerge, keys2PostMerge)
 
   t.is(hasTruncated, true) // Sanity check
-  t.is(bee1.core.indexedLength, 3, 'Snapshot indexedLength increased, because it is now confirmed')
-  t.is(bee1.version, 3, 'bee1 snapshot version did not change')
+  t.is(bee1.core.indexedLength, 3, 'indexedLength increased')
+  t.is(bee1.version, 3, 'version did not change')
 
-  t.is(bee2.core.indexedLength, 2, 'bee2 snapshot indexed length did not change')
-  t.is(bee2.version, 4, 'bee2 snapshot version did not change')
+  t.is(bee2.core.indexedLength, 2, 'indexedLength did not change')
+  t.is(bee2.version, 4, 'version did not change')
 })
 
 test('check cloning detached snapshot', async t => {


### PR DESCRIPTION
<strike>The `indexedLength` of a snapshot can change atm, which shouldn't happen

Haven't figured out the cause yet, but here is a test illustrating the issue</strike>

The expected behaviour is in fact that the indexedLength can grow (up to maximum the core length at the time of creating the snapshot), if the snapshot blocks get confirmed