### PR TITLE
v1 oplog message format

### DIFF
--- a/index.js
+++ b/index.js
@@ -1555,7 +1555,7 @@ module.exports = class Autobase extends ReadyResource {
       tally.set(this.maxSupportedVersion, local)
     }
 
-    for (const { versionSignal: version } of heads) {
+    for (const { maxSupportedVersion: version } of heads) {
       let v = tally.get(version)
 
       if (!v) {
@@ -1669,7 +1669,7 @@ module.exports = class Autobase extends ReadyResource {
 
       blocks[i] = {
         version: 1,
-        versionSignal: this.maxSupportedVersion,
+        maxSupportedVersion: this.maxSupportedVersion,
         checkpoint: this._addCheckpoints ? await generateCheckpoint(cores) : null,
         digest: this._addCheckpoints ? this._generateDigest() : null,
         node: {

--- a/index.js
+++ b/index.js
@@ -1225,6 +1225,9 @@ module.exports = class Autobase extends ReadyResource {
     await this._makeLinearizer(this.system)
     await this._advanceBootRecord(length)
 
+    // manually set the digest
+    if (migrate) this._setDigest(migrate.key)
+
     const to = length
 
     if (b4a.equals(this.fastForwardTo.key, key) && this.fastForwardTo.length === length) {
@@ -1603,12 +1606,11 @@ module.exports = class Autobase extends ReadyResource {
     if (this._localDigest === null) {
       this._localDigest = await this.localWriter.getDigest()
 
+      // no previous digest available
       if (this._localDigest === null) {
-        this._localDigest = {
-          pointer: 0,
-          key: this.system.core.key
-        }
+        this._setDigest(this.system.core.key)
       }
+
       return
     }
 
@@ -1628,8 +1630,13 @@ module.exports = class Autobase extends ReadyResource {
 
     if (this._localDigest.key && b4a.equals(key, this._localDigest.key)) return
 
-    this._localDigest.pointer = 0
+    this._setDigest(key)
+  }
+
+  _setDigest (key) {
+    if (this._localDigest === null) this._localDigest = {}
     this._localDigest.key = key
+    this._localDigest.pointer = 0
   }
 
   _generateDigest () {

--- a/index.js
+++ b/index.js
@@ -1678,19 +1678,16 @@ module.exports = class Autobase extends ReadyResource {
       const { value, heads, batch } = localNodes[i]
 
       blocks[i] = {
-        version: 0,
-        digest: this._addCheckpoints ? this._generateDigest() : null,
+        version: 1,
+        versionSignal: this.maxSupportedVersion,
         checkpoint: this._addCheckpoints ? await generateCheckpoint(cores) : null,
+        digest: this._addCheckpoints ? this._generateDigest() : null,
         node: {
           heads,
           batch,
           value: value === null ? null : c.encode(this.valueEncoding, value)
         },
-        additional: {
-          pointer: 0,
-          data: {}
-        },
-        versionSignal: this.maxSupportedVersion
+        trace: []
       }
 
       if (this._addCheckpoints) this._localDigest.pointer++

--- a/index.js
+++ b/index.js
@@ -1387,6 +1387,9 @@ module.exports = class Autobase extends ReadyResource {
       if (!update.indexers && !upgraded) continue
 
       this._queueIndexFlush(i)
+
+      // we have to set the digest here so it is
+      // flushed to local appends in same iteration
       await this._updateDigest()
 
       return u.indexed.slice(i).concat(u.tip)
@@ -1480,14 +1483,14 @@ module.exports = class Autobase extends ReadyResource {
 
       // indexer set has updated
       this._queueIndexFlush(i + 1)
-      await this._updateDigest()
+      await this._updateDigest() // see above
 
       return u.indexed.slice(i + 1).concat(u.tip)
     }
 
     if (u.indexed.length) {
       this._queueIndexFlush(u.indexed.length)
-      await this._updateDigest()
+      await this._updateDigest() // see above
     }
 
     return null
@@ -1609,6 +1612,7 @@ module.exports = class Autobase extends ReadyResource {
       return
     }
 
+    // we predict what the system key will be after flushing
     const pending = this.system.core._source.pendingIndexedLength
     const info = await this.system.getIndexedInfo(pending)
 

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -118,26 +118,6 @@ const Checkpoint = c.array({
   }
 })
 
-const Node = {
-  preencode (state, m) {
-    Clock.preencode(state, m.heads)
-    c.uint.preencode(state, m.batch)
-    c.buffer.preencode(state, m.value)
-  },
-  encode (state, m) {
-    Clock.encode(state, m.heads)
-    c.uint.encode(state, m.batch)
-    c.buffer.encode(state, m.value)
-  },
-  decode (state, m) {
-    return {
-      heads: Clock.decode(state),
-      batch: c.uint.decode(state),
-      value: c.buffer.decode(state)
-    }
-  }
-}
-
 const Indexer = {
   preencode (state, m) {
     c.uint.preencode(state, m.signature)
@@ -157,9 +137,10 @@ const Indexer = {
     }
   }
 }
+
 const Indexers = c.array(Indexer)
 
-const Digest = {
+const DigestV0 = {
   preencode (state, m) {
     c.uint.preencode(state, m.pointer)
     if (m.pointer === 0) {
@@ -180,6 +161,49 @@ const Digest = {
     }
   }
 }
+
+const Digest = {
+  preencode (state, m) {
+    c.uint.preencode(state, m.pointer)
+    if (m.pointer === 0) {
+      c.fixed32.preencode(state, m.key)
+    }
+  },
+  encode (state, m) {
+    c.uint.encode(state, m.pointer)
+    if (m.pointer === 0) {
+      c.fixed32.encode(state, m.key)
+    }
+  },
+  decode (state) {
+    const pointer = c.uint.decode(state)
+    return {
+      pointer,
+      key: pointer === 0 ? c.fixed32.decode(state) : null
+    }
+  }
+}
+
+const Node = {
+  preencode (state, m) {
+    Clock.preencode(state, m.heads)
+    c.uint.preencode(state, m.batch)
+    c.buffer.preencode(state, m.value)
+  },
+  encode (state, m) {
+    Clock.encode(state, m.heads)
+    c.uint.encode(state, m.batch)
+    c.buffer.encode(state, m.value)
+  },
+  decode (state, m) {
+    return {
+      heads: Clock.decode(state),
+      batch: c.uint.decode(state),
+      value: c.buffer.decode(state)
+    }
+  }
+}
+
 
 const Additional = {
   preencode (state, m) {
@@ -219,15 +243,93 @@ const AdditionalData = {
   }
 }
 
+const Trace = c.array(c.uint)
+
 const OplogMessage = {
   preencode (state, m) {
     c.uint.preencode(state, m.version)
+    c.uint.preencode(state, m.versionSignal)
 
+    const isCheckpointer = m.digest !== null && m.checkpoint !== null
+
+    let flags = 0
+    if (isCheckpointer) flags |= 1
+
+    c.uint.preencode(state, flags)
+
+    if (isCheckpointer) {
+      Checkpoint.preencode(state, m.checkpoint)
+      Digest.preencode(state, m.digest)
+    }
+
+    Node.preencode(state, m.node)
+    Trace.preencode(state, m.trace)
+  },
+  encode (state, m) {
+    c.uint.encode(state, m.version)
+    c.uint.encode(state, m.versionSignal)
+
+    const isCheckpointer = m.digest !== null && m.checkpoint !== null
+
+    let flags = 0
+    if (isCheckpointer) flags |= 1
+
+    c.uint.encode(state, flags)
+
+    if (isCheckpointer) {
+      Checkpoint.encode(state, m.checkpoint)
+      Digest.encode(state, m.digest)
+    }
+
+    Node.encode(state, m.node)
+    Trace.encode(state, m.trace)
+  },
+  decode (state) {
+    const version = c.uint.decode(state)
+
+    if (version === 0) {
+      const m = c.decode(OplogMessageV0, state)
+
+      return {
+        version,
+        versionSignal: m.versionSignal,
+        digest: null,
+        checkpoint: m.checkpoint,
+        node: m.node,
+        trace: []
+      }
+    }
+
+    const versionSignal = c.uint.decode(state)
+
+    const flags = c.uint.decode(state)
+
+    const isCheckpointer = (flags & 1) !== 0
+
+    const checkpoint = isCheckpointer ? Checkpoint.decode(state) : null
+    const digest = isCheckpointer ? Digest.decode(state) : null
+
+    const node = Node.decode(state)
+    const trace = Trace.decode(state)
+
+    return {
+      version,
+      versionSignal,
+      digest,
+      checkpoint,
+      node,
+      trace
+    }
+  }
+}
+
+const OplogMessageV0 = {
+  preencode (state, m) {
     const isCheckpointer = m.digest !== null && m.checkpoint !== null
     c.uint.preencode(state, isCheckpointer ? 1 : 0)
 
     if (isCheckpointer) {
-      Digest.preencode(state, m.digest)
+      DigestV0.preencode(state, m.digest)
       Checkpoint.preencode(state, m.checkpoint)
     }
 
@@ -243,7 +345,7 @@ const OplogMessage = {
     c.uint.encode(state, isCheckpointer ? 1 : 0)
 
     if (isCheckpointer) {
-      Digest.encode(state, m.digest)
+      DigestV0.encode(state, m.digest)
       Checkpoint.encode(state, m.checkpoint)
     }
 
@@ -258,7 +360,7 @@ const OplogMessage = {
 
     const isCheckpointer = (flags & 1) !== 0
 
-    const digest = isCheckpointer ? Digest.decode(state) : null
+    const digest = isCheckpointer ? DigestV0.decode(state) : null
     const checkpoint = isCheckpointer ? Checkpoint.decode(state) : null
     const node = Node.decode(state)
     const additional = Additional.decode(state)

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -247,7 +247,7 @@ const Trace = c.array(c.uint)
 const OplogMessage = {
   preencode (state, m) {
     c.uint.preencode(state, m.version)
-    c.uint.preencode(state, m.versionSignal)
+    c.uint.preencode(state, m.maxSupportedVersion)
 
     const isCheckpointer = m.digest !== null && m.checkpoint !== null
 
@@ -266,7 +266,7 @@ const OplogMessage = {
   },
   encode (state, m) {
     c.uint.encode(state, m.version)
-    c.uint.encode(state, m.versionSignal)
+    c.uint.encode(state, m.maxSupportedVersion)
 
     const isCheckpointer = m.digest !== null && m.checkpoint !== null
 
@@ -291,7 +291,7 @@ const OplogMessage = {
 
       return {
         version,
-        versionSignal: m.versionSignal,
+        maxSupportedVersion: m.maxSupportedVersion,
         digest: null,
         checkpoint: m.checkpoint,
         node: m.node,
@@ -299,7 +299,7 @@ const OplogMessage = {
       }
     }
 
-    const versionSignal = c.uint.decode(state)
+    const maxSupportedVersion = c.uint.decode(state)
 
     const flags = c.uint.decode(state)
 
@@ -313,7 +313,7 @@ const OplogMessage = {
 
     return {
       version,
-      versionSignal,
+      maxSupportedVersion,
       digest,
       checkpoint,
       node,
@@ -335,7 +335,7 @@ const OplogMessageV0 = {
     Node.preencode(state, m.node)
 
     Additional.preencode(state, m.additional) // at the btm so it can be edited
-    c.uint.preencode(state, m.versionSignal)
+    c.uint.preencode(state, m.maxSupportedVersion)
   },
   encode (state, m) {
     c.uint.encode(state, m.version)
@@ -351,7 +351,7 @@ const OplogMessageV0 = {
     Node.encode(state, m.node)
 
     Additional.encode(state, m.additional)
-    c.uint.encode(state, m.versionSignal)
+    c.uint.encode(state, m.maxSupportedVersion)
   },
   decode (state) {
     const flags = c.uint.decode(state)
@@ -362,7 +362,7 @@ const OplogMessageV0 = {
     const checkpoint = isCheckpointer ? Checkpoint.decode(state) : null
     const node = Node.decode(state)
     const additional = Additional.decode(state)
-    const versionSignal = state.start < state.end ? c.uint.decode(state) : 0
+    const maxSupportedVersion = state.start < state.end ? c.uint.decode(state) : 0
 
     return {
       version: 0,
@@ -370,7 +370,7 @@ const OplogMessageV0 = {
       checkpoint,
       node,
       additional,
-      versionSignal
+      maxSupportedVersion
     }
   }
 }

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -204,7 +204,6 @@ const Node = {
   }
 }
 
-
 const Additional = {
   preencode (state, m) {
     c.uint.preencode(state, m.pointer)

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -287,7 +287,7 @@ const OplogMessage = {
     const version = c.uint.decode(state)
 
     if (version === 0) {
-      const m = c.decode(OplogMessageV0, state)
+      const m = OplogMessageV0.decode(state)
 
       return {
         version,
@@ -354,7 +354,6 @@ const OplogMessageV0 = {
     c.uint.encode(state, m.versionSignal)
   },
   decode (state) {
-    const version = c.uint.decode(state)
     const flags = c.uint.decode(state)
 
     const isCheckpointer = (flags & 1) !== 0
@@ -366,7 +365,7 @@ const OplogMessageV0 = {
     const versionSignal = state.start < state.end ? c.uint.decode(state) : 0
 
     return {
-      version,
+      version: 0,
       digest,
       checkpoint,
       node,

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -253,14 +253,14 @@ module.exports = class Writer extends ReadyResource {
   async _loadNextNode () {
     const seq = this.nodes.length
     if (!(await this.core.has(seq))) return false
-    const { node, checkpoint, versionSignal } = await this.core.get(seq, { wait: false })
+    const { node, checkpoint, maxSupportedVersion } = await this.core.get(seq, { wait: false })
 
     if (this.isIndexer && checkpoint) {
       this._addCheckpoints(checkpoint)
     }
 
     const value = node.value == null ? null : c.decode(this.base.valueEncoding, node.value)
-    this.node = Linearizer.createNode(this, seq + 1, value, node.heads, node.batch, new Set(), versionSignal)
+    this.node = Linearizer.createNode(this, seq + 1, value, node.heads, node.batch, new Set(), maxSupportedVersion)
     return true
   }
 

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -162,7 +162,7 @@ module.exports = class Writer extends ReadyResource {
 
     const node = await this.core.get(length - 1)
 
-    return node.versionSignal
+    return node.maxSupportedVersion
   }
 
   async getDigest (length = this.core.length) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -1008,7 +1008,8 @@ test('basic - oplog digest', async t => {
   const last = await base1.local.get(1)
 
   t.is(last.digest.pointer, 0)
-  t.is(last.digest.indexers?.length, 2)
+  t.is(base2.system.core.getBackingCore().manifest.signers.length, 2)
+  t.alike(last.digest.key, base2.system.core.key)
 })
 
 // todo: use normal helper once we have hypercore session manager


### PR DESCRIPTION
This PR updates the oplog message format to be the following:
```
{
  version: <uint>
  versionSignal: <uint>
  flags: <uint>,
  checkpoint: {
    pointer: <uint>
    checkpoint: [{
      signature: <fixed64>,
      length: c.uint
    }]
  },
  digest: {
    pointer: <uint>,
    key: <fixed64>
  },
  node: {
    heads: [{
      key: <fixed32>,
      length: <uint>
    }],
    batch: <uint>,
    value: <buffer>
  },
  trace: [<uint>]
}
```