### PR TITLE
Handle drain exceptions in one place only 

### DIFF
--- a/index.js
+++ b/index.js
@@ -1430,7 +1430,7 @@ module.exports = class Autobase extends ReadyResource {
       // autobase version was bumped
       let upgraded = false
       if (update.version > this.version) {
-        this._onUpgrade(update.version)
+        this._onUpgrade(update.version) // throws if not supported
         upgraded = true
       }
 
@@ -1520,7 +1520,7 @@ module.exports = class Autobase extends ReadyResource {
       // autobase version was bumped
       let upgraded = false
       if (update.version > this.version) {
-        this._onUpgrade(update.version)
+        this._onUpgrade(update.version) // throws if not supported
         upgraded = true
       }
 

--- a/index.js
+++ b/index.js
@@ -499,6 +499,9 @@ module.exports = class Autobase extends ReadyResource {
 
   async append (value) {
     if (!this.opened) await this.ready()
+
+    if (this.closing) throw new Error('Autobase is closing')
+
     await this._advanced // ensure all local state has been applied, only needed until persistent batches
 
     // if a reset is scheduled await those

--- a/index.js
+++ b/index.js
@@ -754,10 +754,7 @@ module.exports = class Autobase extends ReadyResource {
   }
 
   _onUpgrade (version) {
-    if (version > this.maxSupportedVersion) {
-      this._onError(new Error('Autobase upgrade required'))
-      return false
-    }
+    if (version > this.maxSupportedVersion) throw new Error('Autobase upgrade required')
     return true
   }
 
@@ -1430,8 +1427,7 @@ module.exports = class Autobase extends ReadyResource {
 
       // autobase version was bumped
       let upgraded = false
-      if (update.version > this.version) {
-        if (!this._onUpgrade(update.version)) return // failed
+      if (update.version > this.version && this._onUpgrade(update.version)) {
         upgraded = true
       }
 
@@ -1496,12 +1492,7 @@ module.exports = class Autobase extends ReadyResource {
       if (this.system.bootstrapping) await this._bootstrap()
 
       if (applyBatch.length && this._hasApply === true) {
-        try {
-          await this._handlers.apply(applyBatch, this.view, this)
-        } catch (err) {
-          this._onError(err)
-          return null
-        }
+        await this._handlers.apply(applyBatch, this.view, this)
       }
 
       update.indexers = !!this.system.indexerUpdate
@@ -1525,8 +1516,7 @@ module.exports = class Autobase extends ReadyResource {
 
       // autobase version was bumped
       let upgraded = false
-      if (update.version > this.version) {
-        if (!this._onUpgrade(update.version)) return // failed
+      if (update.version > this.version && this._onUpgrade(update.version)) {
         upgraded = true
       }
 

--- a/index.js
+++ b/index.js
@@ -758,7 +758,6 @@ module.exports = class Autobase extends ReadyResource {
 
   _onUpgrade (version) {
     if (version > this.maxSupportedVersion) throw new Error('Autobase upgrade required')
-    return true
   }
 
   _addLocalHeads () {
@@ -1430,7 +1429,8 @@ module.exports = class Autobase extends ReadyResource {
 
       // autobase version was bumped
       let upgraded = false
-      if (update.version > this.version && this._onUpgrade(update.version)) {
+      if (update.version > this.version) {
+        this._onUpgrade(update.version)
         upgraded = true
       }
 
@@ -1519,7 +1519,8 @@ module.exports = class Autobase extends ReadyResource {
 
       // autobase version was bumped
       let upgraded = false
-      if (update.version > this.version && this._onUpgrade(update.version)) {
+      if (update.version > this.version) {
+        this._onUpgrade(update.version)
         upgraded = true
       }
 

--- a/test/upgrade.js
+++ b/test/upgrade.js
@@ -20,6 +20,7 @@ test('upgrade - do not proceed', async t => {
     apply: applyv0,
     open,
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -29,6 +30,7 @@ test('upgrade - do not proceed', async t => {
     apply: applyv0,
     open,
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -49,6 +51,7 @@ test('upgrade - do not proceed', async t => {
     apply: applyv1,
     open,
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -75,6 +78,7 @@ test('upgrade - proceed', async t => {
     apply: applyv0,
     open,
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -84,6 +88,7 @@ test('upgrade - proceed', async t => {
     apply: applyv0,
     open,
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -104,6 +109,7 @@ test('upgrade - proceed', async t => {
     apply: applyv1,
     open,
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -128,6 +134,7 @@ test('upgrade - proceed', async t => {
     apply: applyv1,
     open,
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -144,6 +151,7 @@ test('upgrade - consensus', async t => {
     apply: applyv0,
     open,
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -153,6 +161,7 @@ test('upgrade - consensus', async t => {
     apply: applyv0,
     open,
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -206,6 +215,7 @@ test('upgrade - consensus', async t => {
     apply: applyv1,
     open,
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -223,6 +233,7 @@ test('upgrade - consensus 3 writers', async t => {
     apply: applyv0,
     open,
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -232,6 +243,7 @@ test('upgrade - consensus 3 writers', async t => {
     apply: applyv0,
     open,
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -241,6 +253,7 @@ test('upgrade - consensus 3 writers', async t => {
     apply: applyv0,
     open,
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -266,6 +279,7 @@ test('upgrade - consensus 3 writers', async t => {
     apply: applyv1,
     open,
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -322,6 +336,7 @@ test('upgrade - consensus 3 writers', async t => {
     apply: applyv1,
     open,
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -344,6 +359,7 @@ test('upgrade - writer cannot append while behind', async t => {
     apply: applyv0,
     open,
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -353,6 +369,7 @@ test('upgrade - writer cannot append while behind', async t => {
     apply: applyv0,
     open,
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -362,6 +379,7 @@ test('upgrade - writer cannot append while behind', async t => {
     apply: applyv0,
     open,
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -387,6 +405,7 @@ test('upgrade - writer cannot append while behind', async t => {
     apply: applyv1,
     open,
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -398,6 +417,7 @@ test('upgrade - writer cannot append while behind', async t => {
     apply: applyv1,
     open,
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -439,6 +459,7 @@ test('upgrade - onindex hook', async t => {
     apply: applyv0,
     open,
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -448,6 +469,7 @@ test('upgrade - onindex hook', async t => {
     apply: applyv0,
     open,
     encryptionKey,
+    ackInterval: 0,
     onindex: async () => {
       const view = b0.view.version
       if (!view.indexedLength) return
@@ -473,6 +495,7 @@ test('upgrade - onindex hook', async t => {
     apply: applyv1,
     open,
     encryptionKey,
+    ackInterval: 0,
     onindex: async () => {
       const view = a1.view.version
       if (!view.indexedLength) return
@@ -505,6 +528,7 @@ test('upgrade - onindex hook', async t => {
     apply: applyv1,
     open,
     encryptionKey,
+    ackInterval: 0,
     onindex: async () => {
       const view = b1.view.version
       if (!view.indexedLength) return
@@ -526,6 +550,7 @@ test('autobase upgrade - do not proceed', async t => {
     apply,
     open: store => store.get('view', { valueEncoding: 'json' }),
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -537,6 +562,7 @@ test('autobase upgrade - do not proceed', async t => {
     apply,
     open: store => store.get('view', { valueEncoding: 'json' }),
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -557,6 +583,7 @@ test('autobase upgrade - do not proceed', async t => {
     apply,
     open: store => store.get('view', { valueEncoding: 'json' }),
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -586,6 +613,7 @@ test('autobase upgrade - proceed', async t => {
     apply,
     open: store => store.get('view', { valueEncoding: 'json' }),
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -597,6 +625,7 @@ test('autobase upgrade - proceed', async t => {
     apply,
     open: store => store.get('view', { valueEncoding: 'json' }),
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -617,6 +646,7 @@ test('autobase upgrade - proceed', async t => {
     apply,
     open: store => store.get('view', { valueEncoding: 'json' }),
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -644,6 +674,7 @@ test('autobase upgrade - proceed', async t => {
     apply,
     open: store => store.get('view', { valueEncoding: 'json' }),
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -663,6 +694,7 @@ test('autobase upgrade - consensus', async t => {
     apply,
     open: store => store.get('test', { valueEncoding: 'json' }),
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -674,6 +706,7 @@ test('autobase upgrade - consensus', async t => {
     apply,
     open: store => store.get('test', { valueEncoding: 'json' }),
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -698,6 +731,7 @@ test('autobase upgrade - consensus', async t => {
     apply,
     open: store => store.get('test', { valueEncoding: 'json' }),
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -726,6 +760,7 @@ test('autobase upgrade - consensus', async t => {
     apply,
     open: store => store.get('test', { valueEncoding: 'json' }),
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -747,6 +782,7 @@ test('autobase upgrade - consensus 3 writers', async t => {
     apply,
     open: store => store.get('test', { valueEncoding: 'json' }),
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -758,6 +794,7 @@ test('autobase upgrade - consensus 3 writers', async t => {
     apply,
     open: store => store.get('test', { valueEncoding: 'json' }),
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -767,6 +804,7 @@ test('autobase upgrade - consensus 3 writers', async t => {
     apply,
     open: store => store.get('test', { valueEncoding: 'json' }),
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -793,6 +831,7 @@ test('autobase upgrade - consensus 3 writers', async t => {
     apply,
     open: store => store.get('test', { valueEncoding: 'json' }),
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -800,6 +839,7 @@ test('autobase upgrade - consensus 3 writers', async t => {
     apply,
     open: store => store.get('test', { valueEncoding: 'json' }),
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -830,6 +870,7 @@ test('autobase upgrade - consensus 3 writers', async t => {
     apply,
     open: store => store.get('test', { valueEncoding: 'json' }),
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -855,6 +896,7 @@ test('autobase upgrade - downgrade', async t => {
     apply,
     open: store => store.get('test', { valueEncoding: 'json' }),
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -872,6 +914,7 @@ test('autobase upgrade - downgrade', async t => {
     apply,
     open: store => store.get('test', { valueEncoding: 'json' }),
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -897,6 +940,7 @@ test('autobase upgrade - downgrade', async t => {
     apply,
     open: store => store.get('test', { valueEncoding: 'json' }),
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -912,6 +956,7 @@ test('autobase upgrade - downgrade then restart', async t => {
     apply,
     open: store => store.get('test', { valueEncoding: 'json' }),
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -929,6 +974,7 @@ test('autobase upgrade - downgrade then restart', async t => {
     apply,
     open: store => store.get('test', { valueEncoding: 'json' }),
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -953,6 +999,7 @@ test('autobase upgrade - downgrade then restart', async t => {
     apply,
     open: store => store.get('test', { valueEncoding: 'json' }),
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -965,6 +1012,7 @@ test('autobase upgrade - downgrade then restart', async t => {
     apply,
     open: store => store.get('test', { valueEncoding: 'json' }),
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -984,6 +1032,7 @@ test('autobase upgrade - downgrade then restart', async t => {
     apply,
     open: store => store.get('test', { valueEncoding: 'json' }),
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -1007,6 +1056,7 @@ test('autobase upgrade - upgrade before writer joins', async t => {
     apply,
     open: store => store.get('test', { valueEncoding: 'json' }),
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   }
 
@@ -1038,6 +1088,7 @@ test('autobase upgrade - fix borked version', async t => {
     apply,
     open: store => store.get('test', { valueEncoding: 'json' }),
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   }
 
@@ -1142,6 +1193,7 @@ test('autobase upgrade - downgrade then fix bork', async t => {
     apply,
     open: store => store.get('test', { valueEncoding: 'json' }),
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   }
 
@@ -1371,6 +1423,7 @@ test('autobase upgrade - non monotonic version', async t => {
     apply,
     open: store => store.get('test', { valueEncoding: 'json' }),
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -1382,6 +1435,7 @@ test('autobase upgrade - non monotonic version', async t => {
     apply,
     open: store => store.get('test', { valueEncoding: 'json' }),
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -1398,6 +1452,7 @@ test('autobase upgrade - non monotonic version', async t => {
     apply,
     open: store => store.get('test', { valueEncoding: 'json' }),
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -1421,6 +1476,7 @@ test('autobase upgrade - non monotonic version', async t => {
     apply,
     open: store => store.get('test', { valueEncoding: 'json' }),
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 
@@ -1432,6 +1488,7 @@ test('autobase upgrade - non monotonic version', async t => {
     apply,
     open: store => store.get('test', { valueEncoding: 'json' }),
     encryptionKey,
+    ackInterval: 0,
     valueEncoding: 'json'
   })
 

--- a/test/upgrade.js
+++ b/test/upgrade.js
@@ -279,6 +279,9 @@ test('upgrade - consensus 3 writers', async t => {
   const berror = new Promise((resolve, reject) => b0.once('error', reject))
   const cerror = new Promise((resolve, reject) => c0.once('error', reject))
 
+  berror.catch(() => {}) // catch error
+  cerror.catch(() => {}) // catch error
+
   await a1.append({ version: 1, data: '5' })
   await replicateAndSync([a1, b0, c0])
 

--- a/test/upgrade.js
+++ b/test/upgrade.js
@@ -61,11 +61,7 @@ test('upgrade - do not proceed', async t => {
 
   await a1.append({ version: 1, data: '3' })
 
-  const error = new Promise((resolve, reject) => b0.on('error', reject))
-
-  replicateAndSync([a1, b0])
-
-  await t.exception(error, /Upgrade required/)
+  await t.exception(replicateAndSync([a1, b0]), /Upgrade required/)
 
   t.is(a1.view.data.indexedLength, 4)
   t.is(b0.view.data.indexedLength, 3)
@@ -119,11 +115,7 @@ test('upgrade - proceed', async t => {
 
   await a1.append({ version: 1, data: '3' })
 
-  const error = new Promise((resolve, reject) => b0.on('error', reject))
-
-  replicateAndSync([a1, b0])
-
-  await t.exception(error, /Upgrade required/)
+  await t.exception(replicateAndSync([a1, b0]), /Upgrade required/)
 
   t.is(a1.view.data.indexedLength, 4)
   t.is(b0.view.data.indexedLength, 3)
@@ -195,17 +187,13 @@ test('upgrade - consensus', async t => {
 
   await a1.append({ version: 1, data: '3' })
 
-  const error = new Promise((resolve, reject) => b0.on('error', reject))
-
-  replicateAndSync([a1, b0])
-
   t.is(a1.view.data.indexedLength, 3)
   t.is(b0.view.data.indexedLength, 3)
 
   t.is(a1.view.data.length, 4)
   t.is(b0.view.data.length, 3)
 
-  await t.exception(error, /Upgrade required/)
+  await t.exception(replicateAndSync([a1, b0]), /Upgrade required/)
 
   t.is(b0.view.data.indexedLength, 3) // should not advance
 
@@ -429,11 +417,7 @@ test('upgrade - writer cannot append while behind', async t => {
   t.is(a1.view.data.indexedLength, 4)
   t.is(b1.view.data.indexedLength, 4)
 
-  const error = new Promise((resolve, reject) => c0.on('error', reject))
-
-  replicateAndSync([a1, c0])
-
-  await t.exception(error, /Upgrade required/)
+  await t.exception(replicateAndSync([a1, c0]), /Upgrade required/)
 
   const len = c0.local.length
   await t.exception(c0.append({ version: 0, data: '5' }))
@@ -510,11 +494,7 @@ test('upgrade - onindex hook', async t => {
 
   await a1.append({ version: 1, data: '3' })
 
-  const error = new Promise((resolve, reject) => b0.on('error', reject))
-
-  replicateAndSync([a1, b0])
-
-  await t.exception(error, /Upgrade required/)
+  await t.exception(replicateAndSync([a1, b0]), /Upgrade required/)
 
   t.is(a1.view.data.indexedLength, 4)
   t.is(b0.view.data.indexedLength, 3)
@@ -596,11 +576,7 @@ test('autobase upgrade - do not proceed', async t => {
 
   await a1.append({ data: '3' })
 
-  const error = new Promise((resolve, reject) => b0.on('error', reject))
-
-  replicateAndSync([a1, b0])
-
-  await t.exception(error, /Autobase upgrade required/)
+  await t.exception(replicateAndSync([a1, b0]), /Autobase upgrade required/)
 
   t.is(a1.view.indexedLength, 4)
   t.is(b0.view.indexedLength, 3)
@@ -659,11 +635,7 @@ test('autobase upgrade - proceed', async t => {
 
   await a1.append({ data: '3' })
 
-  const error = new Promise((resolve, reject) => b0.on('error', reject))
-
-  replicateAndSync([a1, b0])
-
-  await t.exception(error, /Autobase upgrade required/)
+  await t.exception(replicateAndSync([a1, b0]), /Autobase upgrade required/)
 
   t.is(a1.view.indexedLength, 4)
   t.is(b0.view.indexedLength, 3)
@@ -853,11 +825,7 @@ test('autobase upgrade - consensus 3 writers', async t => {
   await a1.append({ data: '5' })
   await c1.append({ data: '6' })
 
-  const berror = new Promise((resolve, reject) => b0.once('error', reject))
-
-  confirm([a1, b0, c1])
-
-  await t.exception(berror, /Autobase upgrade required/)
+  await t.exception(confirm([a1, b0, c1]), /Autobase upgrade required/)
 
   t.is((await b0.system.getIndexedInfo()).version, version)
   t.ok(b0.closing)

--- a/test/upgrade.js
+++ b/test/upgrade.js
@@ -436,7 +436,7 @@ test('upgrade - writer cannot append while behind', async t => {
   await t.exception(error, /Upgrade required/)
 
   const len = c0.local.length
-  await c0.append({ version: 0, data: '5' })
+  await t.exception(c0.append({ version: 0, data: '5' }))
 
   t.is(c0.local.length, len) // did not append
   t.is(c0.view.data.indexedLength, 3)
@@ -1153,11 +1153,11 @@ test('autobase upgrade - fix borked version', async t => {
   const aerr = new Promise((resolve, reject) => a1.once('error', reject))
   const berr = new Promise((resolve, reject) => b1.once('error', reject))
 
-  a1.append('three', /Block/)
-  b1.append('three', /Block/)
+  a1.append('three')
+  b1.append('three')
 
-  await t.exception(aerr)
-  await t.exception(berr)
+  await t.exception(aerr, /Block/)
+  await t.exception(berr, /Block/)
 
   await a1.close()
   await b1.close()

--- a/test/upgrade.js
+++ b/test/upgrade.js
@@ -817,7 +817,7 @@ test('autobase upgrade - consensus 3 writers', async t => {
   await t.exception(berror, /Autobase upgrade required/)
 
   t.is((await b0.system.getIndexedInfo()).version, version)
-  t.ok(b0.closed)
+  t.ok(b0.closing)
 
   t.is(b0.view.indexedLength, 3) // should not advance
 


### PR DESCRIPTION
This PR also patches upgrade tests which had previously been depending on unintentional autoack behaviour