### PR TITLE
Add eagerReady option

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,7 +134,9 @@ module.exports = class Autobase extends ReadyResource {
     this.system = new SystemView(this._viewStore.get({ name: '_system', exclusive: true, cache: true }))
     this.view = this._hasOpen ? this._handlers.open(this._viewStore, this) : null
 
-    this.ready().catch(safetyCatch)
+    if (handlers.eagerReady !== false) {
+      this.ready().catch(safetyCatch)
+    }
   }
 
   [inspect] (depth, opts) {


### PR DESCRIPTION
Makes it easier to explicitly control when reindexing starts if I construct many bases in parallel