### PR TITLE
Expose maxCacheSize opt (for system db)

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,6 +131,8 @@ module.exports = class Autobase extends ReadyResource {
     this.system = null
     this.version = -1
 
+    this.maxCacheSize = handlers.maxCacheSize || null
+
     const {
       ackInterval = DEFAULT_ACK_INTERVAL,
       ackThreshold = DEFAULT_ACK_THRESHOLD
@@ -150,7 +152,11 @@ module.exports = class Autobase extends ReadyResource {
 
     this._waiting = new SignalPromise()
 
-    this.system = new SystemView(this._viewStore.get({ name: '_system', exclusive: true }))
+    this.system = new SystemView(
+      this._viewStore.get({ name: '_system', exclusive: true }),
+      0,
+      { maxCacheSize: this.maxCacheSize }
+    )
     this.view = this._hasOpen ? this._handlers.open(this._viewStore, this) : null
 
     this.ready().catch(safetyCatch)
@@ -316,7 +322,7 @@ module.exports = class Autobase extends ReadyResource {
       return { bootstrap, system: null, heads: [] }
     }
 
-    const system = new SystemView(core, length)
+    const system = new SystemView(core, length, { maxCacheSize: this.maxCacheSize })
     await system.ready()
 
     if (system.version > this.maxSupportedVersion) {
@@ -406,7 +412,7 @@ module.exports = class Autobase extends ReadyResource {
     const core = this.store.get({ key, encryptionKey, isBlockKey: true }).batch({ checkout: length, session: false })
 
     const base = this
-    const system = new SystemView(core, length)
+    const system = new SystemView(core, length, { maxCacheSize: this.maxCacheSize })
     await system.ready()
 
     const indexerCores = []
@@ -1551,7 +1557,7 @@ module.exports = class Autobase extends ReadyResource {
         await core.get(length - 1, { timeout })
       }
 
-      const system = new SystemView(core.session(), length)
+      const system = new SystemView(core.session(), length, { maxCacheSize: this.maxCacheSize })
       await system.ready()
 
       if (system.version > this.maxSupportedVersion) {
@@ -1670,7 +1676,7 @@ module.exports = class Autobase extends ReadyResource {
       return
     }
 
-    const system = new SystemView(core, length)
+    const system = new SystemView(core, length, { maxCacheSize: this.maxCacheSize })
     await system.ready()
 
     const opened = []

--- a/index.js
+++ b/index.js
@@ -131,7 +131,7 @@ module.exports = class Autobase extends ReadyResource {
     this.system = null
     this.version = -1
 
-    this.maxCacheSize = handlers.maxCacheSize || null
+    this.maxCacheSize = handlers.maxCacheSize || 0 // 0 means the hyperbee default cache size will be used
 
     const {
       ackInterval = DEFAULT_ACK_INTERVAL,

--- a/index.js
+++ b/index.js
@@ -152,13 +152,13 @@ module.exports = class Autobase extends ReadyResource {
 
     this._waiting = new SignalPromise()
 
-    this.system = new SystemView(
-      this._viewStore.get({ name: '_system', exclusive: true }),
-      {
-        checkout: 0,
-        maxCacheSize: this.maxCacheSize
-      }
-    )
+    const sysCore = this._viewStore.get({ name: '_system', exclusive: true })
+
+    this.system = new SystemView(sysCore, {
+      checkout: 0,
+      maxCacheSize: this.maxCacheSize
+    })
+
     this.view = this._hasOpen ? this._handlers.open(this._viewStore, this) : null
 
     this.ready().catch(safetyCatch)
@@ -324,13 +324,11 @@ module.exports = class Autobase extends ReadyResource {
       return { bootstrap, system: null, heads: [] }
     }
 
-    const system = new SystemView(
-      core,
-      {
-        checkout: length,
-        maxCacheSize: this.maxCacheSize
-      }
-    )
+    const system = new SystemView(core, {
+      checkout: length,
+      maxCacheSize: this.maxCacheSize
+    })
+
     await system.ready()
 
     if (system.version > this.maxSupportedVersion) {
@@ -420,13 +418,11 @@ module.exports = class Autobase extends ReadyResource {
     const core = this.store.get({ key, encryptionKey, isBlockKey: true }).batch({ checkout: length, session: false })
 
     const base = this
-    const system = new SystemView(
-      core,
-      {
-        checkout: length,
-        maxCacheSize: this.maxCacheSize
-      }
-    )
+    const system = new SystemView(core, {
+      checkout: length,
+      maxCacheSize: this.maxCacheSize
+    })
+
     await system.ready()
 
     const indexerCores = []
@@ -1571,13 +1567,11 @@ module.exports = class Autobase extends ReadyResource {
         await core.get(length - 1, { timeout })
       }
 
-      const system = new SystemView(
-        core.session(),
-        {
-          checkout: length,
-          maxCacheSize: this.maxCacheSize
-        }
-      )
+      const system = new SystemView(core.session(), {
+        checkout: length,
+        maxCacheSize: this.maxCacheSize
+      })
+
       await system.ready()
 
       if (system.version > this.maxSupportedVersion) {
@@ -1696,13 +1690,11 @@ module.exports = class Autobase extends ReadyResource {
       return
     }
 
-    const system = new SystemView(
-      core,
-      {
-        checkout: length,
-        maxCacheSize: this.maxCacheSize
-      }
-    )
+    const system = new SystemView(core, {
+      checkout: length,
+      maxCacheSize: this.maxCacheSize
+    })
+
     await system.ready()
 
     const opened = []

--- a/index.js
+++ b/index.js
@@ -154,8 +154,10 @@ module.exports = class Autobase extends ReadyResource {
 
     this.system = new SystemView(
       this._viewStore.get({ name: '_system', exclusive: true }),
-      0,
-      { maxCacheSize: this.maxCacheSize }
+      {
+        checkout: 0,
+        maxCacheSize: this.maxCacheSize
+      }
     )
     this.view = this._hasOpen ? this._handlers.open(this._viewStore, this) : null
 
@@ -322,7 +324,13 @@ module.exports = class Autobase extends ReadyResource {
       return { bootstrap, system: null, heads: [] }
     }
 
-    const system = new SystemView(core, length, { maxCacheSize: this.maxCacheSize })
+    const system = new SystemView(
+      core,
+      {
+        checkout: length,
+        maxCacheSize: this.maxCacheSize
+      }
+    )
     await system.ready()
 
     if (system.version > this.maxSupportedVersion) {
@@ -412,7 +420,13 @@ module.exports = class Autobase extends ReadyResource {
     const core = this.store.get({ key, encryptionKey, isBlockKey: true }).batch({ checkout: length, session: false })
 
     const base = this
-    const system = new SystemView(core, length, { maxCacheSize: this.maxCacheSize })
+    const system = new SystemView(
+      core,
+      {
+        checkout: length,
+        maxCacheSize: this.maxCacheSize
+      }
+    )
     await system.ready()
 
     const indexerCores = []
@@ -1557,7 +1571,13 @@ module.exports = class Autobase extends ReadyResource {
         await core.get(length - 1, { timeout })
       }
 
-      const system = new SystemView(core.session(), length, { maxCacheSize: this.maxCacheSize })
+      const system = new SystemView(
+        core.session(),
+        {
+          checkout: length,
+          maxCacheSize: this.maxCacheSize
+        }
+      )
       await system.ready()
 
       if (system.version > this.maxSupportedVersion) {
@@ -1676,7 +1696,13 @@ module.exports = class Autobase extends ReadyResource {
       return
     }
 
-    const system = new SystemView(core, length, { maxCacheSize: this.maxCacheSize })
+    const system = new SystemView(
+      core,
+      {
+        checkout: length,
+        maxCacheSize: this.maxCacheSize
+      }
+    )
     await system.ready()
 
     const opened = []

--- a/lib/system.js
+++ b/lib/system.js
@@ -73,7 +73,7 @@ module.exports = class SystemView extends ReadyResource {
       this.core.session(),
       {
         checkout: length,
-        maxCacheSize: this.maxCacheSize
+        maxCacheSize: this.db.maxCacheSize
       }
     )
     await checkout.ready()

--- a/lib/system.js
+++ b/lib/system.js
@@ -12,14 +12,13 @@ const DIGEST = subs.sub(b4a.from([0]))
 const MEMBERS = subs.sub(b4a.from([1]))
 
 module.exports = class SystemView extends ReadyResource {
-  constructor (core, opts = {}) {
+  constructor (core, { checkout = 0, maxCacheSize = 0 } = {}) {
     super()
 
     this.core = core
 
-    const checkout = opts.checkout || 0
     // sessions is a workaround for batches not having sessions atm...
-    this.db = new Hyperbee(core, { keyEncoding: 'binary', extension: false, checkout, sessions: typeof core.session === 'function', maxCacheSize: opts.maxCacheSize })
+    this.db = new Hyperbee(core, { keyEncoding: 'binary', extension: false, checkout, sessions: typeof core.session === 'function', maxCacheSize })
 
     this.version = -1 // set version in apply
     this.members = 0

--- a/lib/system.js
+++ b/lib/system.js
@@ -12,12 +12,12 @@ const DIGEST = subs.sub(b4a.from([0]))
 const MEMBERS = subs.sub(b4a.from([1]))
 
 module.exports = class SystemView extends ReadyResource {
-  constructor (core, checkout = 0) {
+  constructor (core, checkout = 0, opts = {}) {
     super()
 
     this.core = core
     // sessions is a workaround for batches not having sessions atm...
-    this.db = new Hyperbee(core, { keyEncoding: 'binary', extension: false, checkout, sessions: typeof core.session === 'function' })
+    this.db = new Hyperbee(core, { keyEncoding: 'binary', extension: false, checkout, sessions: typeof core.session === 'function', maxCacheSize: opts.maxCacheSize })
 
     this.version = -1 // set version in apply
     this.members = 0

--- a/lib/system.js
+++ b/lib/system.js
@@ -69,13 +69,11 @@ module.exports = class SystemView extends ReadyResource {
   }
 
   async checkout (length) {
-    const checkout = new SystemView(
-      this.core.session(),
-      {
-        checkout: length,
-        maxCacheSize: this.db.maxCacheSize
-      }
-    )
+    const checkout = new SystemView(this.core.session(), {
+      checkout: length,
+      maxCacheSize: this.db.maxCacheSize
+    })
+
     await checkout.ready()
 
     return checkout

--- a/lib/system.js
+++ b/lib/system.js
@@ -12,10 +12,12 @@ const DIGEST = subs.sub(b4a.from([0]))
 const MEMBERS = subs.sub(b4a.from([1]))
 
 module.exports = class SystemView extends ReadyResource {
-  constructor (core, checkout = 0, opts = {}) {
+  constructor (core, opts = {}) {
     super()
 
     this.core = core
+
+    const checkout = opts.checkout || 0
     // sessions is a workaround for batches not having sessions atm...
     this.db = new Hyperbee(core, { keyEncoding: 'binary', extension: false, checkout, sessions: typeof core.session === 'function', maxCacheSize: opts.maxCacheSize })
 
@@ -68,7 +70,13 @@ module.exports = class SystemView extends ReadyResource {
   }
 
   async checkout (length) {
-    const checkout = new SystemView(this.core.session(), length)
+    const checkout = new SystemView(
+      this.core.session(),
+      {
+        checkout: length,
+        maxCacheSize: this.maxCacheSize
+      }
+    )
     await checkout.ready()
 
     return checkout

--- a/lib/system.js
+++ b/lib/system.js
@@ -68,10 +68,10 @@ module.exports = class SystemView extends ReadyResource {
     }
   }
 
-  async checkout (length) {
+  async checkout (length, { maxCacheSize = this.db.maxCacheSize } = {}) {
     const checkout = new SystemView(this.core.session(), {
       checkout: length,
-      maxCacheSize: this.db.maxCacheSize
+      maxCacheSize
     })
 
     await checkout.ready()

--- a/test/basic.js
+++ b/test/basic.js
@@ -1616,6 +1616,21 @@ test('basic - writer adds a writer while being removed', async t => {
   t.is(binfo.isRemoved, true)
 })
 
+test('basic - maxCacheSize opt', async t => {
+  const [store] = await createStores(1, t)
+  const base = new Autobase(store.namespace('with-cache'), null, { maxCacheSize: 10 })
+  await base.ready()
+  t.is(base.maxCacheSize, 10, 'maxCacheSize set')
+  t.is(base.system.db.maxCacheSize, 10, 'maxCacheSize applied to sys db')
+})
+
+test('basic - maxCacheSize has null default', async t => {
+  const [store] = await createStores(1, t)
+  const base = new Autobase(store.namespace('with-cache'))
+  await base.ready()
+  t.is(base.maxCacheSize, null, 'maxCacheSize default null')
+})
+
 // todo: this test is hard, probably have to rely on ff to recover
 test.skip('basic - writer adds a writer while being removed', async t => {
   const { bases } = await create(4, t, { apply: applyWithRemove })

--- a/test/basic.js
+++ b/test/basic.js
@@ -1624,11 +1624,11 @@ test('basic - maxCacheSize opt', async t => {
   t.is(base.system.db.maxCacheSize, 10, 'maxCacheSize applied to sys db')
 })
 
-test('basic - maxCacheSize has null default', async t => {
+test('basic - maxCacheSize has 0 default', async t => {
   const [store] = await createStores(1, t)
   const base = new Autobase(store.namespace('with-cache'))
   await base.ready()
-  t.is(base.maxCacheSize, null, 'maxCacheSize default null')
+  t.is(base.maxCacheSize, 0, 'maxCacheSize default 0')
 })
 
 // todo: this test is hard, probably have to rely on ff to recover


### PR DESCRIPTION
Note: the current implementation is not ideal for maintaining, given that the `SystemView` is created in 5 different places and it needs to be explicitly passed the `maxCacheSize` option every time. Might make sense to refactor to a `createSystemView(core, length)` method which is called in each of those 5 cases, where `createSystemView` is responsible for adding the opts (for now only `maxCacheSize`).