### PR TITLE
Use global cache passed through corestore if available

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ module.exports = class Autobase extends ReadyResource {
     this.keyPair = handlers.keyPair || null
     this.valueEncoding = c.from(handlers.valueEncoding || 'binary')
     this.store = store
-
+    this.globalCache = store.globalCache
     this.encrypted = handlers.encrypted || !!handlers.encryptionKey
     this.encryptionKey = handlers.encryptionKey || null
 

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ module.exports = class Autobase extends ReadyResource {
     this.keyPair = handlers.keyPair || null
     this.valueEncoding = c.from(handlers.valueEncoding || 'binary')
     this.store = store
-    this.globalCache = store.globalCache
+    this.globalCache = store.globalCache || null
     this.encrypted = handlers.encrypted || !!handlers.encryptionKey
     this.encryptionKey = handlers.encryptionKey || null
 
@@ -131,8 +131,6 @@ module.exports = class Autobase extends ReadyResource {
     this.system = null
     this.version = -1
 
-    this.maxCacheSize = handlers.maxCacheSize || 0 // 0 means the hyperbee default cache size will be used
-
     const {
       ackInterval = DEFAULT_ACK_INTERVAL,
       ackThreshold = DEFAULT_ACK_THRESHOLD
@@ -155,8 +153,7 @@ module.exports = class Autobase extends ReadyResource {
     const sysCore = this._viewStore.get({ name: '_system', exclusive: true })
 
     this.system = new SystemView(sysCore, {
-      checkout: 0,
-      maxCacheSize: this.maxCacheSize
+      checkout: 0
     })
 
     this.view = this._hasOpen ? this._handlers.open(this._viewStore, this) : null
@@ -325,8 +322,7 @@ module.exports = class Autobase extends ReadyResource {
     }
 
     const system = new SystemView(core, {
-      checkout: length,
-      maxCacheSize: this.maxCacheSize
+      checkout: length
     })
 
     await system.ready()
@@ -419,8 +415,7 @@ module.exports = class Autobase extends ReadyResource {
 
     const base = this
     const system = new SystemView(core, {
-      checkout: length,
-      maxCacheSize: this.maxCacheSize
+      checkout: length
     })
 
     await system.ready()

--- a/lib/core.js
+++ b/lib/core.js
@@ -106,7 +106,7 @@ class AutocoreSession extends EventEmitter {
     this._index = source.sessions.push(this) - 1
     this._snapshot = snapshot
 
-    this.globalCache = this.base.store.globalCache
+    this.globalCache = this.base.globalCache
 
     this.ready().catch(safetyCatch)
   }

--- a/lib/core.js
+++ b/lib/core.js
@@ -101,12 +101,11 @@ class AutocoreSession extends EventEmitter {
 
     this.activeRequests = []
     this.valueEncoding = valueEncoding || null
+    this.globalCache = this.base.globalCache
 
     this._source = source
     this._index = source.sessions.push(this) - 1
     this._snapshot = snapshot
-
-    this.globalCache = this.base.globalCache
 
     this.ready().catch(safetyCatch)
   }

--- a/lib/core.js
+++ b/lib/core.js
@@ -106,6 +106,8 @@ class AutocoreSession extends EventEmitter {
     this._index = source.sessions.push(this) - 1
     this._snapshot = snapshot
 
+    this.globalCache = this.base.store.globalCache
+
     this.ready().catch(safetyCatch)
   }
 

--- a/lib/core.js
+++ b/lib/core.js
@@ -101,7 +101,7 @@ class AutocoreSession extends EventEmitter {
 
     this.activeRequests = []
     this.valueEncoding = valueEncoding || null
-    this.globalCache = this.base.globalCache
+    this.globalCache = source.base.globalCache
 
     this._source = source
     this._index = source.sessions.push(this) - 1

--- a/lib/system.js
+++ b/lib/system.js
@@ -12,13 +12,13 @@ const DIGEST = subs.sub(b4a.from([0]))
 const MEMBERS = subs.sub(b4a.from([1]))
 
 module.exports = class SystemView extends ReadyResource {
-  constructor (core, { checkout = 0, maxCacheSize = 0 } = {}) {
+  constructor (core, { checkout = 0 } = {}) {
     super()
 
     this.core = core
 
     // sessions is a workaround for batches not having sessions atm...
-    this.db = new Hyperbee(core, { keyEncoding: 'binary', extension: false, checkout, sessions: typeof core.session === 'function', maxCacheSize })
+    this.db = new Hyperbee(core, { keyEncoding: 'binary', extension: false, checkout, sessions: typeof core.session === 'function' })
 
     this.version = -1 // set version in apply
     this.members = 0
@@ -68,10 +68,9 @@ module.exports = class SystemView extends ReadyResource {
     }
   }
 
-  async checkout (length, { maxCacheSize = this.db.maxCacheSize } = {}) {
+  async checkout (length) {
     const checkout = new SystemView(this.core.session(), {
-      checkout: length,
-      maxCacheSize
+      checkout: length
     })
 
     await checkout.ready()

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "core-coupler": "^1.0.0",
     "debounceify": "^1.0.0",
     "hyperbee": "^2.15.0",
-    "hypercore": "holepunchto/hypercore#rache-global-approach",
+    "hypercore": "^10.37.10",
     "hypercore-crypto": "^3.4.0",
     "hypercore-id-encoding": "^1.2.0",
     "mutexify": "^1.4.0",
@@ -50,7 +50,7 @@
   "devDependencies": {
     "autobase-test-helpers": "^2.0.1",
     "brittle": "^3.1.1",
-    "corestore": "holepunchto/corestore#global-cache-opt",
+    "corestore": "^6.18.3",
     "rache": "^1.0.0",
     "random-access-memory": "^6.2.0",
     "same-data": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "core-coupler": "^1.0.0",
     "debounceify": "^1.0.0",
     "hyperbee": "^2.15.0",
-    "hypercore": "^10.37.1",
+    "hypercore": "holepunchto/hypercore#rache-global-approach",
     "hypercore-crypto": "^3.4.0",
     "hypercore-id-encoding": "^1.2.0",
     "mutexify": "^1.4.0",
@@ -50,7 +50,8 @@
   "devDependencies": {
     "autobase-test-helpers": "^2.0.1",
     "brittle": "^3.1.1",
-    "corestore": "^6.16.1",
+    "corestore": "holepunchto/corestore#global-cache-opt",
+    "rache": "^1.0.0",
     "random-access-memory": "^6.2.0",
     "same-data": "^1.0.0",
     "standard": "^17.0.0",

--- a/test/basic.js
+++ b/test/basic.js
@@ -3,6 +3,7 @@ const ram = require('random-access-memory')
 const Corestore = require('corestore')
 const b4a = require('b4a')
 const crypto = require('hypercore-crypto')
+const Rache = require('rache')
 
 const Autobase = require('..')
 
@@ -1616,19 +1617,16 @@ test('basic - writer adds a writer while being removed', async t => {
   t.is(binfo.isRemoved, true)
 })
 
-test('basic - maxCacheSize opt', async t => {
-  const [store] = await createStores(1, t)
-  const base = new Autobase(store.namespace('with-cache'), null, { maxCacheSize: 10 })
-  await base.ready()
-  t.is(base.maxCacheSize, 10, 'maxCacheSize set')
-  t.is(base.system.db.maxCacheSize, 10, 'maxCacheSize applied to sys db')
-})
+test('basic - sessions use globalCache from corestore if it is set', async t => {
+  const globalCache = new Rache()
 
-test('basic - maxCacheSize has 0 default', async t => {
-  const [store] = await createStores(1, t)
-  const base = new Autobase(store.namespace('with-cache'))
+  const [store] = await createStores(1, t, { globalCache })
+  const base = createBase(store, null, t)
   await base.ready()
-  t.is(base.maxCacheSize, 0, 'maxCacheSize default 0')
+
+  t.is(base.globalCache, globalCache, 'globalCache set on autobase itself')
+  t.is(base.view.globalCache, globalCache, 'passed to autocore sessions')
+  t.is(base.system.core.globalCache, globalCache, 'passed to system')
 })
 
 // todo: this test is hard, probably have to rely on ff to recover

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -31,7 +31,8 @@ async function createStores (n, t, opts = {}) {
   const stores = []
   for (let i = offset; i < n + offset; i++) {
     const primaryKey = Buffer.alloc(32, i)
-    stores.push(new Corestore(await storage(), { primaryKey, encryptionKey }))
+    const globalCache = opts.globalCache || null
+    stores.push(new Corestore(await storage(), { primaryKey, encryptionKey, globalCache }))
   }
 
   t.teardown(() => Promise.all(stores.map(s => s.close())), { order: 2 })


### PR DESCRIPTION
Relies on https://github.com/holepunchto/hypercore/pull/535 and https://github.com/holepunchto/corestore/pull/94 (so draft PR)

Exposes the `globalCache` on its autocore sessions, if the corestore it was passed exposes it. This makes them compatible with the hypercore (with the linked PR). In particular, views generated from this autobase will use the globalCache (assuming hyperbee PR https://github.com/holepunchto/hyperbee/pull/161 is used).

This makes the `maxCacheSize` opt redundant, so I removed it. Technically this is a breaking change, but it was an unofficial option anyway (and no harm done if it's still passed in, it's just ignored).