### PR TITLE
Increase `ackInterval` in 'autoack - value beneath null values' test

### DIFF
--- a/test/autoack.js
+++ b/test/autoack.js
@@ -266,7 +266,7 @@ test('autoack - value beneath null values', async t => {
   t.plan(4)
 
   const { bases } = await create(2, t, {
-    ackInterval: 10,
+    ackInterval: 100,
     ackThreshold: 0
   })
 


### PR DESCRIPTION
Previously the test could fail when an ack triggered during checks for `sync()`. The ack would complete before the final promise resolved in `sync()` causing the length stored before the 1s timeout to be the final resolved length that is supposed to be different.

This is just a timing issue where the 'before' is remembered after the 'after' is complete.

100ms didn't flake after ~195 runs mining the test. Previously the test flaked after ~20-30 runs. Increasing the `ackInterval` doesn't significantly increase the test time as it is less than the 1s timeout waiting for the ack.