### PR TITLE
Remove `async` from example `open` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ A view is one or more hypercores whose contents are created by deterministically
 Autobase accepts an `open` function for creating views and an `apply` function that can be used to update the views based on the writer nodes.
 
 ```js
-async function open (store) {
+function open (store) {
   return store.get('my-view')
 }
 ```


### PR DESCRIPTION
`open` doesn't return a promise so this example could mislead users of the library and confuse them when `base.view` is a promise.