### PR TITLE
Set ApplyState.applying when doing optimistic updates

### DIFF
--- a/lib/apply-state.js
+++ b/lib/apply-state.js
@@ -905,11 +905,13 @@ module.exports = class ApplyState extends ReadyResource {
 
     let failed = false
 
+    this.applying = true
     try {
       await this.base._handlers.apply(applyBatch, this.view, this.hostcalls)
     } catch {
       failed = true
     }
+    this.applying = false
 
     if (!failed) {
       const post = await this.system.get(key)


### PR DESCRIPTION
Done outside of the `try/catch` because errors are expected