### PR TITLE
Add examples toc readme

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,13 @@
+# Autobase Examples
+
+## Table of Contents
+
+- [`basic`](./basic/)  
+  Show cases how to define the `open` & `apply` handlers with support for
+  adding a peer as a writer.
+- [`autobase-example`](https://github.com/holepunchto/autobase-example)  
+  A full E2E example with command line flags for enabling swarming, adding
+  writers, etc.
+- [`external-pointer-pattern`](./external-pointer-pattern/)  
+  An example of a helpful pattern for side loading large data to improve indexer speed &
+  reduce the overall size of an `autobase`.

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,7 +2,7 @@
 
 ## Table of Contents
 
-- [`basic`](./basic/)  
+- [`basic`](./basic/index.mjs)  
   Show cases how to define the `open` & `apply` handlers with support for
   adding a peer as a writer.
 - [`autobase-example`](https://github.com/holepunchto/autobase-example)  


### PR DESCRIPTION
Adds a README.md in `examples` to be a table of contents for examples, even external ones like `autobase-example`.