### PR TITLE
Allow the encryptionKey opt to be a promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -314,6 +314,10 @@ module.exports = class Autobase extends ReadyResource {
 
     this.keyPair = (await this._handlers.keyPair) || null
 
+    if (!this.encryptionKey && this._handlers.encryptionKey) {
+      this.encryptionKey = await this._handlers.encryptionKey
+    }
+
     const result = await boot(this.store, this.key, {
       encryptionKey: this.encryptionKey,
       encrypt: this.encrypt,

--- a/index.js
+++ b/index.js
@@ -101,7 +101,7 @@ module.exports = class Autobase extends ReadyResource {
 
     this.encrypted = handlers.encrypted || !!handlers.encryptionKey
     this.encrypt = !!handlers.encrypt
-    this.encryptionKey = handlers.encryptionKey || null
+    this.encryptionKey = null
     this.encryption = null
 
     this.activeBatch = null // maintained by the append-batch
@@ -314,7 +314,7 @@ module.exports = class Autobase extends ReadyResource {
 
     this.keyPair = (await this._handlers.keyPair) || null
 
-    if (!this.encryptionKey && this._handlers.encryptionKey) {
+    if (this._handlers.encryptionKey !== null) {
       this.encryptionKey = await this._handlers.encryptionKey
     }
 

--- a/test/encryption.js
+++ b/test/encryption.js
@@ -90,6 +90,43 @@ test('encryption - expect encryption key', async t => {
   await closing
 })
 
+test('encryption - pass as promise', async t => {
+  const tmp = await tmpDir(t)
+  const store = new Corestore(tmp)
+
+  const key = b4a.alloc(32).fill('secret')
+  const encryptionKey = new Promise(resolve => setTimeout(resolve, 1000, key))
+
+  const base = new Autobase(store, { apply, open, ackInterval: 0, ackThreshold: 0, encryptionKey })
+  await base.ready()
+
+  t.alike(base.encryptionKey, key)
+
+  await base.append('you should not see me')
+
+  t.alike(await base.view.get(0), 'you should not see me')
+  t.is(base.view.signedLength, 1)
+  t.is(base.system.core.signedLength, 3)
+
+  let found = false
+
+  for (const core of store.cores) {
+    const session = store.get(core.key)
+    await session.setEncryptionKey(null) // ensure no auto decryption
+
+    for (let i = 0; i < core.length; i++) {
+      const buf = await session.get(i, { valueEncoding: 'ascii' })
+      if (buf.indexOf('you should not see me') > -1) found = true
+    }
+
+    await session.close()
+  }
+
+  t.absent(found)
+
+  await base.close()
+})
+
 function open (store) {
   return store.get('view', { valueEncoding: 'json' })
 }

--- a/test/encryption.js
+++ b/test/encryption.js
@@ -8,7 +8,9 @@ const Autobase = require('..')
 test('encryption - basic', async t => {
   const tmp = await tmpDir(t)
   const store = new Corestore(tmp)
+
   const base = new Autobase(store, { apply, open, ackInterval: 0, ackThreshold: 0, encryptionKey: b4a.alloc(32).fill('secret') })
+  await base.ready()
 
   t.ok(base.encryptionKey)
 
@@ -40,7 +42,9 @@ test('encryption - basic', async t => {
 test('encryption - restart', async t => {
   const tmp = await tmpDir(t)
   const store = new Corestore(tmp)
+
   const base = new Autobase(store, { apply, open, ackInterval: 0, ackThreshold: 0, encryptionKey: b4a.alloc(32).fill('secret') })
+  await base.ready()
 
   t.ok(base.encryptionKey)
 


### PR DESCRIPTION
Follows the same pattern we use for the `wakeup` and `keyPair` options