### PR TITLE
Add test that fails w/o `validateFork`'s `this.pendingIndexedLength()` check

### DIFF
--- a/test/fork.js
+++ b/test/fork.js
@@ -521,7 +521,7 @@ test('fork - forking to the future is invalid', async t => {
 
   await b.append({
     fork: {
-      indexers: [b].map(idx => b4a.toString(idx.local.key, 'hex')),
+      indexers: [b4a.toString(b.local.key, 'hex')],
       system: {
         key: b4a.toString(b.system.core.key, 'hex'),
         length: 1337 // A dramatically future length


### PR DESCRIPTION
Trying to fork to the future should not be possible and when it is not guarded against will error.