### PR TITLE
Validate fork system length against prologue

### DIFF
--- a/lib/apply-state.js
+++ b/lib/apply-state.js
@@ -305,6 +305,7 @@ module.exports = class ApplyState extends ReadyResource {
 
   async validateFork (indexerKeys, system) {
     if (!b4a.equals(system.key, this.system.core.key)) return false
+    if (this.system.core.state.prologue.length >= system.length) return false
     if (this.pendingIndexedLength() < system.length) return false
     for (const key of indexerKeys) {
       const info = await this.system.get(key)


### PR DESCRIPTION
If in `apply` the `host.system.core.key` is used as the system key to fork from, then the system will fork once correctly, setting the prologue for the new indexers, but then will fail on reapplying post fork.

While this might be discouraged as a pattern, the prologue should always be behind the system fork length regardless so should be validated.