### PR TITLE
Add test that fails because of BLOCK_NOT_AVAILABLE error

### DIFF
--- a/test/fork.js
+++ b/test/fork.js
@@ -83,6 +83,71 @@ test('fork - one writer to another', async t => {
   t.is(await b.view.get(3), 'post fork')
 })
 
+test.solo('fork - with indexer active', async t => {
+  const { bases } = await create(2, t, {
+    encryptionKey: b4a.alloc(32, 0),
+    apply: applyFork
+  })
+
+  const [a, b] = bases
+
+  await a.append('one')
+  await a.append('two')
+  await a.append('three')
+
+  await addWriter(a, b, false)
+  await confirm(bases)
+
+  await b.append('b writes!')
+
+  await confirm(bases)
+
+  t.is(a.view.signedLength, 4)
+  t.is(b.view.signedLength, 4)
+
+  t.is(b.system.indexers.length, 1)
+  t.alike(b.system.indexers[0].key, a.local.key)
+
+  await b.append('start election')
+
+  await b.append('vote for me!')
+
+  await replicateAndSync(bases)
+
+  const whenQuorumReached = a.indexedLength
+  await a.append(`i agree, b should be in charge as of ${whenQuorumReached}`)
+
+  // Voting "Quorum" is reached so signal fork using
+  await a.append({
+    fork: {
+      indexers: [b4a.toString(b.local.key, 'hex')],
+      system: {
+        key: b4a.toString(b.system.core.key, 'hex'),
+        length: whenQuorumReached
+      }
+    }
+  })
+  // BUG ^ This will cause a fork that truncates the ApplyState's system core but leaves the ApplyState's indexedLength higher than the new truncated system core length.
+  // This causes BLOCK_NOT_AVAILABLE error when rebooting & checking out the system view. Truncation seems to happen in `Fork` aka `lib/fork.js` when _upgrade() gets the system at the new length:
+  // ```
+  // this.system = new SystemView(await this._get('_system', this.length))
+  // ```
+
+  await replicateAndSync(bases)
+
+  t.is(b.view.length, 7)
+  t.is(b.system.indexers.length, 1)
+  t.alike(b.system.indexers[0].key, b.local.key)
+
+  await t.execution(b.append('post fork'))
+
+  t.is(b.view.length, 4)
+  t.alike(b.system.indexers[0].key, b.local.key)
+
+  t.is(await b.view.get(2), 'three')
+  t.is(await b.view.get(3), 'post fork')
+})
+
 test('fork - with unindexed state', async t => {
   const { bases } = await create(3, t, {
     encryptionKey: b4a.alloc(32, 0),


### PR DESCRIPTION
This will cause a fork that truncates the ApplyState's system core but leaves the ApplyState's indexedLength higher than the new truncated system core length. This causes BLOCK_NOT_AVAILABLE error when rebooting & checking out the system view. Truncation seems to happen in `Fork` aka `lib/fork.js` when _upgrade() gets the system at the new length:

```
this.system = new SystemView(await this._get('_system', this.length))
```

Test is solo'ed for now.