### PR TITLE
Support forking to system length before indexedLength on indexers

### DIFF
--- a/lib/apply-state.js
+++ b/lib/apply-state.js
@@ -1175,6 +1175,10 @@ module.exports = class ApplyState extends ReadyResource {
     if (this.pendingFork) {
       const pending = this.pendingFork
       if (pending.length > this.indexedLength) this._indexUpdates(u.indexed.length)
+      if (pending.length < this.indexedLength) {
+        this.localState.clearUpdates()
+        this.updates.splice(0, 0)
+      }
 
       const fork = new Fork(this.base, this.store, this, pending)
       const forked = await fork.upgrade()

--- a/lib/fork.js
+++ b/lib/fork.js
@@ -76,6 +76,7 @@ module.exports = class Fork {
     await sys.ready()
 
     await this._migrate(system, sys, this.system.core, this.system.core.length)
+    this.state.systemView.indexedLength = this.system.core.length
   }
 
   async createView (name, core, linked) {

--- a/test/fork.js
+++ b/test/fork.js
@@ -143,11 +143,10 @@ test.solo('fork - with indexer active', async t => {
 
   await t.execution(b.append('post fork'))
 
-  t.is(b.view.length, 4)
+  t.is(b.view.length, 8)
   t.alike(b.system.indexers[0].key, b.local.key)
 
   t.is(await b.view.get(2), 'three')
-  t.is(await b.view.get(3), 'post fork')
 })
 
 test('fork - with unindexed state', async t => {


### PR DESCRIPTION
This doesn't support forking to before indexed length in general but only fixes the scenario where the indexer progresses the system past a message from a peer (or themselves) to fork.

The fix is to allow `system.fork()` to truncate as currently implemented, but to clear apply state updates and to set the ApplyState `indexedLength` to the length of the new system core. This allows the system core to be checked out at the end instead of the previously indexed length which was greater than the length.

A fix like this is required for a voting system to fork where the indexers vote and can reach a quorum for signing before the vote finalizes. Of course if indexers can reach quorum, then they theoretically shouldn't be forking anyways. But other situations where a network partition happens and the indexers are separate from the rest of the network theoretically, do work while other peers are forking and then the partition is healed, could get into the same type of situations.