### PR TITLE
WIP: Rotating local & uncaught errors

### DIFF
--- a/test/basic.js
+++ b/test/basic.js
@@ -2120,7 +2120,7 @@ test('basic - optimistic append & local rotate', async t => {
 
   await done
 
-  t.is(c.local.key, newKeyPair.publicKey, 'optimistic')
+  t.is(c.local.key, newKeyPair.publicKey, 'local writer was rotated')
   t.is(await a.view.get(a.view.length - 1), 'optimistic')
 })
 


### PR DESCRIPTION
Adds to example test cases:

1. Where an optimistic append happens first which triggers `get` calls on the view and then local rotates.  
    Replicates an invite flow. A peer optimistically appends to join an autobase, the autobase does some get to check, and the peer rotates their local to a new keypair.
2. Where a peer is added as an indexer, appends and then rotates local.  
    Probably shouldn't be allowed given the peer is added as an indexer.

Both test cases error/fail. The `basic - optimistic append & local rotate` test case has an uncaught error. `basic - rotate local after append` catches the error in the `t.execution()` call.