### PR TITLE
Remove instances where promises await in objs can be uncaught

### DIFF
--- a/lib/apply-state.js
+++ b/lib/apply-state.js
@@ -855,14 +855,9 @@ module.exports = class ApplyState extends ReadyResource {
   }
 
   async _signInternalViewCores (sys) {
-    const [system, encryption] = await Promise.all([
-      this._signViewCore(this.systemView.core, this.systemView.indexedLength),
-      this._signViewCore(this.encryptionView.core, sys.encryptionLength)
-    ])
-
     return {
-      system,
-      encryption
+      system: await this._signViewCore(this.systemView.core, this.systemView.indexedLength),
+      encryption: await this._signViewCore(this.encryptionView.core, sys.encryptionLength)
     }
   }
 

--- a/test/fixtures/generate/encryption.js
+++ b/test/fixtures/generate/encryption.js
@@ -42,15 +42,10 @@ async function main () {
 
   for (const data of DATA) await base.append(data)
 
-  const [local, system, view] = await Promise.all([
-    getBlocks(base.local),
-    getBlocks(base.core),
-    getBlocks(base.view)
-  ])
   const fixture = {
-    local,
-    system,
-    view
+    local: await getBlocks(base.local),
+    system: await getBlocks(base.core),
+    view: await getBlocks(base.view)
   }
 
   await fs.writeFile(fixturePath, JSON.stringify(fixture))


### PR DESCRIPTION
The following illustrates how this can occur:
```js
async function test () {
  const a = new Promise((resolve) => setTimeout(resolve, 100))
  const b = Promise.reject(Error('whoops'))

  return {
    a: await a,
    b: await b
  }
}

test().catch(() => console.log('catch'))
```

The `whoops` will reject before `a` is awaited causing it to be uncaught.